### PR TITLE
ci: Add golangci-lint as a tool dependency

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -23,5 +23,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Cache build and module paths
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Run golangci linting checks
-        uses: golangci/golangci-lint-action@v3
+        run: make lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,10 @@ linters-settings:
       alias: metav1
     - pkg: k8s.io/apimachinery/pkg/api/errors
       alias: apierrors
+    - pkg: github.com/operator-framework/rukpak/api/v1alpha1
+      alias: rukpakv1alpha1
+    - pkg: github.com/operator-framework/deppy/api/v1alpha1
+      alias: deppyv1alpha1
   goimports:
     local-prefixes: github.com/operator-framework/deppy
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ vet: ## Run go vet against code.
 tidy: ## Update modules.
 	go mod tidy
 
+.PHONY: lint
+lint: golangci-lint ## Run golangci-lint linter checks.
+	$(GOLANGCI_LINT) run
+
 .PHONY: verify
 verify: generate manifests tidy ## Run verification checks.
 	git diff --exit-code
@@ -131,6 +135,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 KIND ?= $(LOCALBIN)/kind
 GINKGO ?= $(LOCALBIN)/ginkgo
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
@@ -161,3 +166,8 @@ $(KIND): $(LOCALBIN)
 ginkgo: $(GINKGO)
 $(GINKGO): $(LOCALBIN) ## Download ginkgo locally if necessary.
 	GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT)
+$(GOLANGCI_LINT): $(LOCALBIN) ## Download golangci-lint locally if necessary.
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2

--- a/controllers/input_controller.go
+++ b/controllers/input_controller.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	corev1alpha1 "github.com/operator-framework/deppy/api/v1alpha1"
+	deppyv1alpha1 "github.com/operator-framework/deppy/api/v1alpha1"
 )
 
 // InputReconciler reconciles a Input object
@@ -57,6 +57,6 @@ func (r *InputReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 // SetupWithManager sets up the controller with the Manager.
 func (r *InputReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1alpha1.Input{}).
+		For(&deppyv1alpha1.Input{}).
 		Complete(r)
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -28,7 +28,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	corev1alpha1 "github.com/operator-framework/deppy/api/v1alpha1"
+	deppyv1alpha1 "github.com/operator-framework/deppy/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -56,7 +56,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = corev1alpha1.AddToScheme(scheme.Scheme)
+	err = deppyv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	corev1alpha1 "github.com/operator-framework/deppy/api/v1alpha1"
+	deppyv1alpha1 "github.com/operator-framework/deppy/api/v1alpha1"
 	"github.com/operator-framework/deppy/controllers"
 	//+kubebuilder:scaffold:imports
 )
@@ -44,7 +44,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(corev1alpha1.AddToScheme(scheme))
+	utilruntime.Must(deppyv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
Update the Makefile and introduce the golangci-lint target to ensure
that local/CI environments use the same version of the golangci-lint
tool.

Update the sanity workflow and ensure CI is running the `lint` Makefile
target, which runs that golangci-lint target on the repository path.

Because we're replacing the golangci-lint github action with running a
Makefile target, we need to cache the go build/module paths so we don't
increase the overall CI sanity workflow time as that
action was previously handling that for us under-the-hood.

---

Update the root .golangci-lint configuration and enforce the
rukpakv1alpha1 and deppyv1alpha1 package import naming.

---

Fix any linting violations after updating that importas golangc-lint
configuration to enforce deppyv1alpha1 as the package import name.