### PR TITLE
makefile: ensure build-container target produces linux binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ build: ## Build manager binary.
 	CGO_ENABLED=0 go build -o bin/manager main.go
 
 .PHONY: build-container
+build-container: export GOOS=linux
 build-container: build ## Builds provisioner container image locally
 	$(CONTAINER_RUNTIME) build -f Dockerfile -t $(IMG) $(BIN_DIR)
 


### PR DESCRIPTION
Add `export GOOS=linux` to the build-container target ala rukpak. 

Without this the deppy manager crash-loops if `make run` is run on macOS, since the binary build target is unspecified and inherited from the host OS. 