### PR TITLE
Add Entity universe

### DIFF
--- a/internal/universe/entity_universe.go
+++ b/internal/universe/entity_universe.go
@@ -1,0 +1,46 @@
+package universe
+
+import (
+	"github.com/operator-framework/deppy/internal/source"
+)
+
+// TODO: https://github.com/operator-framework/deppy/issues/40
+
+// EntityUniverse represents a queryable set of entities
+// it is used as a basis for creating solver constraints
+type EntityUniverse struct {
+	universe []source.Entity
+	idIndex  map[source.EntityID]source.Entity
+}
+
+func NewEntityUniverse(entities []source.Entity) *EntityUniverse {
+	m := make(map[source.EntityID]source.Entity)
+	for _, entity := range entities {
+		m[entity.ID()] = entity
+	}
+	return &EntityUniverse{
+		universe: entities,
+		idIndex:  m,
+	}
+}
+
+func (u *EntityUniverse) Get(id source.EntityID) *source.Entity {
+	if entity, ok := u.idIndex[id]; ok {
+		return &entity
+	}
+	return nil
+}
+
+func (u *EntityUniverse) Search(predicate Predicate) SearchResult {
+	out := make([]source.Entity, 0)
+	for _, entity := range u.universe {
+		if predicate(&entity) {
+			out = append(out, entity)
+		}
+	}
+	return out
+}
+
+func (u *EntityUniverse) AllEntities() SearchResult {
+	return u.universe
+}

--- a/internal/universe/entity_universe_test.go
+++ b/internal/universe/entity_universe_test.go
@@ -1,0 +1,51 @@
+package universe_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/operator-framework/deppy/internal/source"
+	"github.com/operator-framework/deppy/internal/universe"
+)
+
+var _ = Describe("EntityUniverse", func() {
+	var entityUniverse = universe.NewEntityUniverse([]source.Entity{
+		*source.NewEntity("1", map[string]string{"property": "1"}),
+		*source.NewEntity("2", map[string]string{"property": "2"}),
+		*source.NewEntity("3", map[string]string{"property": "3"}),
+	})
+
+	It("should return entities by id", func() {
+		entity := entityUniverse.Get("1")
+		Expect(entity).NotTo(BeNil())
+		Expect(entity).To(Equal(source.NewEntity("1", map[string]string{"property": "1"})))
+	})
+
+	It("should return nil if the entity is not found", func() {
+		Expect(entityUniverse.Get("not found")).To(BeNil())
+	})
+
+	It("should be searchable", func() {
+		entities := entityUniverse.Search(func(entity *source.Entity) bool {
+			value, err := entity.GetProperty("property")
+			if err != nil {
+				return false
+			}
+			return value <= "2"
+		})
+
+		Expect(entities).To(Equal(universe.SearchResult([]source.Entity{
+			*source.NewEntity("1", map[string]string{"property": "1"}),
+			*source.NewEntity("2", map[string]string{"property": "2"}),
+		})))
+	})
+
+	It("should return all entities", func() {
+		Expect(entityUniverse.AllEntities()).To(Equal(universe.SearchResult([]source.Entity{
+			*source.NewEntity("1", map[string]string{"property": "1"}),
+			*source.NewEntity("2", map[string]string{"property": "2"}),
+			*source.NewEntity("3", map[string]string{"property": "3"}),
+		})))
+	})
+
+})

--- a/internal/universe/search.go
+++ b/internal/universe/search.go
@@ -1,0 +1,59 @@
+package universe
+
+import (
+	"sort"
+
+	"github.com/operator-framework/deppy/internal/source"
+)
+
+type Predicate func(entity *source.Entity) bool
+
+type SearchResult []source.Entity
+type SortFunction func(e1 *source.Entity, e2 *source.Entity) bool
+
+func (r SearchResult) Sort(fn SortFunction) SearchResult {
+	sort.SliceStable(r, func(i, j int) bool {
+		return fn(&r[i], &r[j])
+	})
+	return r
+}
+
+func (r SearchResult) CollectIds() []source.EntityID {
+	ids := make([]source.EntityID, len(r))
+	for i := range r {
+		ids[i] = r[i].ID()
+	}
+	return ids
+}
+
+func And(predicates ...Predicate) Predicate {
+	return func(entity *source.Entity) bool {
+		eval := true
+		for _, predicate := range predicates {
+			eval = eval && predicate(entity)
+			if !eval {
+				return false
+			}
+		}
+		return eval
+	}
+}
+
+func Or(predicates ...Predicate) Predicate {
+	return func(entity *source.Entity) bool {
+		eval := false
+		for _, predicate := range predicates {
+			eval = eval || predicate(entity)
+			if eval {
+				return true
+			}
+		}
+		return eval
+	}
+}
+
+func Not(predicate Predicate) Predicate {
+	return func(entity *source.Entity) bool {
+		return !predicate(entity)
+	}
+}

--- a/internal/universe/search_test.go
+++ b/internal/universe/search_test.go
@@ -1,0 +1,120 @@
+package universe_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/operator-framework/deppy/internal/source"
+	"github.com/operator-framework/deppy/internal/universe"
+)
+
+var _ = Describe("Search", func() {
+	Describe("And Predicate", func() {
+		It("should succeed if all predicates are true", func() {
+			entity := source.NewEntity("id", map[string]string{})
+			predicateOne := func(entity *source.Entity) bool {
+				return true
+			}
+			predicateTwo := func(entity *source.Entity) bool {
+				return true
+			}
+
+			Expect(universe.And(predicateOne)(entity)).To(BeTrue())
+			Expect(universe.And(predicateOne, predicateTwo)(entity)).To(BeTrue())
+		})
+
+		It("should succeed if there are no predicates", func() {
+			entity := source.NewEntity("id", map[string]string{})
+			Expect(universe.And()(entity)).To(BeTrue())
+		})
+
+		It("should fail if one predicate is false", func() {
+			entity := source.NewEntity("id", map[string]string{})
+			predicateOne := func(entity *source.Entity) bool {
+				return false
+			}
+			predicateTwo := func(entity *source.Entity) bool {
+				return true
+			}
+
+			Expect(universe.And(predicateOne)(entity)).To(BeFalse())
+			Expect(universe.And(predicateOne, predicateTwo)(entity)).To(BeFalse())
+		})
+	})
+
+	Describe("Or Predicate", func() {
+		It("should succeed if at least one predicates is true", func() {
+			entity := source.NewEntity("id", map[string]string{})
+			predicateOne := func(entity *source.Entity) bool {
+				return true
+			}
+			predicateTwo := func(entity *source.Entity) bool {
+				return false
+			}
+
+			Expect(universe.Or(predicateOne)(entity)).To(BeTrue())
+			Expect(universe.Or(predicateOne, predicateTwo)(entity)).To(BeTrue())
+		})
+
+		It("should fail if there are no predicates", func() {
+			entity := source.NewEntity("id", map[string]string{})
+			Expect(universe.Or()(entity)).To(BeFalse())
+		})
+
+		It("should fail if all predicates are false", func() {
+			entity := source.NewEntity("id", map[string]string{})
+			predicateOne := func(entity *source.Entity) bool {
+				return false
+			}
+			predicateTwo := func(entity *source.Entity) bool {
+				return false
+			}
+
+			Expect(universe.And(predicateOne)(entity)).To(BeFalse())
+			Expect(universe.And(predicateOne, predicateTwo)(entity)).To(BeFalse())
+		})
+	})
+
+	Describe("Not Predicate", func() {
+		It("should negate a predicate", func() {
+			entity := source.NewEntity("id", map[string]string{})
+			predicateOne := func(entity *source.Entity) bool {
+				return false
+			}
+			predicateTwo := func(entity *source.Entity) bool {
+				return true
+			}
+
+			Expect(universe.Not(predicateOne)(entity)).To(BeTrue())
+			Expect(universe.Not(predicateTwo)(entity)).To(BeFalse())
+		})
+	})
+
+	Describe("SearchResult", func() {
+		It("should be sortable", func() {
+			results := universe.SearchResult([]source.Entity{
+				*source.NewEntity("c", map[string]string{}),
+				*source.NewEntity("a", map[string]string{}),
+				*source.NewEntity("b", map[string]string{}),
+			})
+			sortedResults := results.Sort(func(e1 *source.Entity, e2 *source.Entity) bool {
+				return e1.ID() < e2.ID()
+			})
+			Expect(sortedResults).To(Equal(universe.SearchResult([]source.Entity{
+				*source.NewEntity("a", map[string]string{}),
+				*source.NewEntity("b", map[string]string{}),
+				*source.NewEntity("c", map[string]string{}),
+			})))
+		})
+
+		It("should collect entity ids", func() {
+			results := universe.SearchResult([]source.Entity{
+				*source.NewEntity("c", map[string]string{}),
+				*source.NewEntity("a", map[string]string{}),
+				*source.NewEntity("b", map[string]string{}),
+			})
+			ids := results.CollectIds()
+			Expect(ids).To(Equal([]source.EntityID{"c", "a", "b"}))
+		})
+	})
+})

--- a/internal/universe/universe_suite_test.go
+++ b/internal/universe/universe_suite_test.go
@@ -1,0 +1,13 @@
+package universe_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUniverse(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Universe Suite")
+}


### PR DESCRIPTION
The entity universe represents the complete set of entities over which deppy will operate. The entity universe surfaces methods for searching and sorting entities. The entity universe gives constraint factories the access to the entities in a queryable form, for instance:

```go
func packageDependency(subject solver.Identifier, packageName string, versionRange string) []solver.Constraint {
  ids := entityUniverse.Search(universe.And(withPackageName(packageName), withinVersion(versionRange))).Sort(byChannelAndVersion).CollectIds()
  return []solver.Constraint{solver.Dependency(subject, ids...)}
}
```

where `withPackageName`, `withinVersion`, `byChannelAndVersion` are `Predicate` and `SortFunction` implementations