### PR TITLE
Bump the golangci-lint tool dependency to v1.49.0

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
 
       - name: Cache build and module paths
         uses: actions/cache@v3

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,23 +5,27 @@ run:
 linters:
   enable:
   - asciicheck
-  - deadcode
+  - bodyclose
   - depguard
   - errorlint
   - gofmt
   - goimports
   - importas
-  - prealloc
-  - nestif
-  - revive
   - misspell
+  - nestif
+  - prealloc
+  - revive
   - stylecheck
   - tparallel
   - unconvert
   - unparam
+  - unused
   - whitespace
 
 linters-settings:
+  errorlint:
+    errorf: false
+
   importas:
     alias:
     - pkg: k8s.io/api/core/v1
@@ -30,6 +34,8 @@ linters-settings:
       alias: metav1
     - pkg: k8s.io/apimachinery/pkg/api/errors
       alias: apierrors
+    - pkg: github.com/operator-framework/deppy/api/v1alpha1
+      alias: deppyv1alpha1
   goimports:
     local-prefixes: github.com/operator-framework/deppy
 

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,10 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.9.0
+ENVTEST_VERSION ?= latest
+KIND_VERSION ?= v0.14.0
+GINKGO_VERSION ?= v2.1.4
+GOLANGCI_LINT_VERSION ?= v1.49.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -161,19 +165,19 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary.
 $(KIND): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kind@v0.14.0
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kind@$(KIND_VERSION)
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO)
 $(GINKGO): $(LOCALBIN) ## Download ginkgo locally if necessary.
-	GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
+	GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT): $(LOCALBIN) ## Download golangci-lint locally if necessary.
-	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.0
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
It looks like we already had the Makefile scaffoldings but golangci-lint wasn't being run in the CI pipeline. Adds the .golanci-lint.yaml configuration file, and leverages the existing "lint" and "verify" Makefile targets to be runs as GHA jobs.