### PR TITLE
Deppy Framework (2/7): EntitySource API

### DIFF
--- a/internal/entitysource/cache_querier.go
+++ b/internal/entitysource/cache_querier.go
@@ -1,0 +1,53 @@
+package entitysource
+
+import "context"
+
+var _ EntityQuerier = &CacheQuerier{}
+
+type CacheQuerier struct {
+	// TODO: separate out a cache
+	entities map[EntityID]Entity
+}
+
+func NewCacheQuerier(entities map[EntityID]Entity) *CacheQuerier {
+	return &CacheQuerier{
+		entities: entities,
+	}
+}
+
+func (c CacheQuerier) Get(_ context.Context, id EntityID) *Entity {
+	if entity, ok := c.entities[id]; ok {
+		return &entity
+	}
+	return nil
+}
+
+func (c CacheQuerier) Filter(_ context.Context, filter Predicate) (EntityList, error) {
+	resultSet := EntityList{}
+	for _, entity := range c.entities {
+		if filter(&entity) {
+			resultSet = append(resultSet, entity)
+		}
+	}
+	return resultSet, nil
+}
+
+func (c CacheQuerier) GroupBy(_ context.Context, fn GroupByFunction) (EntityListMap, error) {
+	resultSet := EntityListMap{}
+	for _, entity := range c.entities {
+		keys := fn(&entity)
+		for _, key := range keys {
+			resultSet[key] = append(resultSet[key], entity)
+		}
+	}
+	return resultSet, nil
+}
+
+func (c CacheQuerier) Iterate(_ context.Context, fn IteratorFunction) error {
+	for _, entity := range c.entities {
+		if err := fn(&entity); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/entitysource/entity.go
+++ b/internal/entitysource/entity.go
@@ -1,0 +1,35 @@
+package entitysource
+
+import "fmt"
+
+type EntityID string
+
+type EntityPropertyNotFoundError string
+
+func (p EntityPropertyNotFoundError) Error() string {
+	return fmt.Sprintf("Property '(%s)' Not Found", string(p))
+}
+
+type Entity struct {
+	id         EntityID
+	properties map[string]string
+}
+
+func NewEntity(id EntityID, properties map[string]string) *Entity {
+	return &Entity{
+		id:         id,
+		properties: properties,
+	}
+}
+
+func (e *Entity) ID() EntityID {
+	return e.id
+}
+
+func (e *Entity) GetProperty(key string) (string, error) {
+	value, ok := e.properties[key]
+	if !ok {
+		return "", EntityPropertyNotFoundError(key)
+	}
+	return value, nil
+}

--- a/internal/entitysource/entity_source.go
+++ b/internal/entitysource/entity_source.go
@@ -1,0 +1,110 @@
+package entitysource
+
+import (
+	"context"
+)
+
+// IteratorFunction is executed for each entity when iterating over all entities
+type IteratorFunction func(entity *Entity) error
+
+// SortFunction returns true if e1 is less than e2
+type SortFunction func(e1 *Entity, e2 *Entity) bool
+
+// GroupByFunction transforms an entity into a slice of keys (strings)
+// over which the entities will be grouped by
+type GroupByFunction func(e1 *Entity) []string
+
+// Predicate returns true if the entity should be kept when filtering
+type Predicate func(entity *Entity) bool
+
+type EntityList []Entity
+type EntityListMap map[string]EntityList
+
+// EntityQuerier is an interface for querying entities in some store
+type EntityQuerier interface {
+	Get(ctx context.Context, id EntityID) *Entity
+	Filter(ctx context.Context, filter Predicate) (EntityList, error)
+	GroupBy(ctx context.Context, fn GroupByFunction) (EntityListMap, error)
+	Iterate(ctx context.Context, fn IteratorFunction) error
+}
+
+// EntityContentGetter is used to retrieve arbitrary content linked to the
+// entities. For instance, the actual package to install, etc.
+type EntityContentGetter interface {
+	GetContent(ctx context.Context, id EntityID) (interface{}, error)
+}
+
+// EntitySource provides a query and content acquisition interface for arbitrary entity stores
+type EntitySource interface {
+	EntityQuerier
+	EntityContentGetter
+}
+
+var _ EntitySource = &Group{}
+
+// Group is a simple EntitySource implementation which groups various entity sources
+// to provide a single interface by which to query them and get content
+type Group struct {
+	entitySources []EntitySource
+}
+
+func NewGroup(entitySources ...EntitySource) *Group {
+	return &Group{
+		entitySources: entitySources,
+	}
+}
+
+// TODO: update implementation to use concurrency, go routines, etc.
+
+func (g *Group) Get(ctx context.Context, id EntityID) *Entity {
+	for _, entitySource := range g.entitySources {
+		if entity := entitySource.Get(ctx, id); entity != nil {
+			return entity
+		}
+	}
+	return nil
+}
+
+func (g *Group) Filter(ctx context.Context, filter Predicate) (EntityList, error) {
+	resultSet := EntityList{}
+	for _, entitySource := range g.entitySources {
+		rs, err := entitySource.Filter(ctx, filter)
+		if err != nil {
+			return nil, err
+		}
+		resultSet = append(resultSet, rs...)
+	}
+	return resultSet, nil
+}
+
+func (g *Group) GroupBy(ctx context.Context, fn GroupByFunction) (EntityListMap, error) {
+	resultSet := EntityListMap{}
+	for _, entitySource := range g.entitySources {
+		rs, err := entitySource.GroupBy(ctx, fn)
+		if err != nil {
+			return nil, err
+		}
+		for key, entities := range rs {
+			resultSet[key] = append(resultSet[key], entities...)
+		}
+	}
+	return resultSet, nil
+}
+
+func (g *Group) Iterate(ctx context.Context, fn IteratorFunction) error {
+	for _, entitySource := range g.entitySources {
+		if err := entitySource.Iterate(ctx, fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *Group) GetContent(ctx context.Context, id EntityID) (interface{}, error) {
+	for _, entitySource := range g.entitySources {
+		if content, err := entitySource.GetContent(ctx, id); err != nil && content != nil {
+			return content, err
+		}
+	}
+	return nil, nil
+}

--- a/internal/entitysource/entity_test.go
+++ b/internal/entitysource/entity_test.go
@@ -1,0 +1,26 @@
+package entitysource_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/operator-framework/deppy/internal/entitysource"
+)
+
+var _ = Describe("Entity", func() {
+	It("stores id and properties", func() {
+		entity := entitysource.NewEntity("id", map[string]string{"prop": "value"})
+		Expect(entity.ID()).To(Equal(entitysource.EntityID("id")))
+
+		value, err := entity.GetProperty("prop")
+		Expect(err).To(BeNil())
+		Expect(value).To(Equal("value"))
+	})
+
+	It("returns not found error when property is not found", func() {
+		entity := entitysource.NewEntity("id", map[string]string{"foo": "value"})
+		value, err := entity.GetProperty("bar")
+		Expect(value).To(Equal(""))
+		Expect(err).To(MatchError(entitysource.EntityPropertyNotFoundError("bar")))
+	})
+})

--- a/internal/entitysource/no_content.go
+++ b/internal/entitysource/no_content.go
@@ -1,0 +1,11 @@
+package entitysource
+
+import "context"
+
+var _ EntityContentGetter = &NoContentSource{}
+
+type NoContentSource struct{}
+
+func (n *NoContentSource) GetContent(_ context.Context, _ EntityID) (interface{}, error) {
+	return nil, nil
+}

--- a/internal/entitysource/query.go
+++ b/internal/entitysource/query.go
@@ -1,0 +1,58 @@
+package entitysource
+
+import "sort"
+
+func (r EntityList) Sort(fn SortFunction) EntityList {
+	sort.SliceStable(r, func(i, j int) bool {
+		return fn(&r[i], &r[j])
+	})
+	return r
+}
+
+func (r EntityList) CollectIds() []EntityID {
+	ids := make([]EntityID, len(r))
+	for i := range r {
+		ids[i] = r[i].ID()
+	}
+	return ids
+}
+
+func (g EntityListMap) Sort(fn SortFunction) EntityListMap {
+	for key := range g {
+		sort.SliceStable(g[key], func(i, j int) bool {
+			return fn(&g[key][i], &g[key][j])
+		})
+	}
+	return g
+}
+func And(predicates ...Predicate) Predicate {
+	return func(entity *Entity) bool {
+		eval := true
+		for _, predicate := range predicates {
+			eval = eval && predicate(entity)
+			if !eval {
+				return false
+			}
+		}
+		return eval
+	}
+}
+
+func Or(predicates ...Predicate) Predicate {
+	return func(entity *Entity) bool {
+		eval := false
+		for _, predicate := range predicates {
+			eval = eval || predicate(entity)
+			if eval {
+				return true
+			}
+		}
+		return eval
+	}
+}
+
+func Not(predicate Predicate) Predicate {
+	return func(entity *Entity) bool {
+		return !predicate(entity)
+	}
+}

--- a/internal/entitysource/source_suite_test.go
+++ b/internal/entitysource/source_suite_test.go
@@ -1,0 +1,13 @@
+package entitysource_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Source Suite")
+}


### PR DESCRIPTION
This PR:

* adds entitysource package:
* exports Entity implementation
* exports EntitySource interface as a combination of two other interfaces: EntityQuerier and EntityContentGetter
* exports entitysource.Group a struct that aggregates multiple entity sources and gives the caller a singular interface for querying and content acquisition
* exports CacheQuerier an implementation of EntityQuerier in which all the data is in-memory
* exports NoContent an implementation of EntityContentGetter that returns no content
**Note**: I may have over engineered things here and separated the interfaces for querying and content acquisition