### PR TITLE
Deppy Framework (6/7): dimacs deppy command

### DIFF
--- a/cmd/dimacs/cmd.go
+++ b/cmd/dimacs/cmd.go
@@ -1,0 +1,75 @@
+package dimacs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/deppy/internal/constraints"
+	"github.com/operator-framework/deppy/internal/entitysource"
+	"github.com/operator-framework/deppy/internal/solver"
+)
+
+func NewDimacsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "solve <path>",
+		Short: "Solves a sat problem given in dimacs format",
+		Long: `Solves a sat problem given in dimacs format. For instance:
+c
+c this is a comment
+c header: p cnf <number of variable> <number of clauses> 
+p cnf 2 2
+c clauses end in zero, negative means 'not'
+c 0 (zero) is not a valid literal
+1 2 0
+1 -2 0
+c cnf: (1 or 2) and (1 and not 2)
+`,
+		Args: cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if _, err := os.Stat(args[0]); errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("file (%s) not found", args[0])
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return solve(args[0])
+		},
+	}
+}
+
+func solve(path string) error {
+	// open dimacs file
+	dimacsFile, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("error opening dimacs file (%s): %w", path, err)
+	}
+	defer dimacsFile.Close()
+
+	dimacs, err := NewDimacs(dimacsFile)
+	if err != nil {
+		return fmt.Errorf("error parsing dimacs file (%s): %w", path, err)
+	}
+
+	// build solver
+	so, err := solver.NewDeppySolver(entitysource.NewGroup(NewDimacsEntitySource(dimacs)), constraints.NewConstraintAggregator(NewDimacsConstraintGenerator(dimacs)))
+	if err != nil {
+		return err
+	}
+
+	// get solution
+	solution, err := so.Solve(context.Background())
+	if err != nil {
+		fmt.Printf("no solution found: %s\n", err)
+	} else {
+		fmt.Println("solution found:")
+		for entityID, selected := range solution {
+			fmt.Printf("%s = %t\n", entityID, selected)
+		}
+	}
+
+	return nil
+}

--- a/cmd/dimacs/dimacs.go
+++ b/cmd/dimacs/dimacs.go
@@ -1,0 +1,150 @@
+package dimacs
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Dimacs constrains the variables and clauses that make up
+// a CNF problem described in DIMACS format
+// see: https://logic.pdmi.ras.ru/~basolver/dimacs.html
+type Dimacs struct {
+	variables []string
+	clauses   []string
+}
+
+func (d *Dimacs) Variables() []string {
+	return d.variables
+}
+
+func (d *Dimacs) Clauses() []string {
+	return d.clauses
+}
+
+// NewDimacs creates a Dimacs struct with the values
+// parsed from the DIMACS formatted stream afforted by dimacsReader
+func NewDimacs(dimacsReader io.Reader) (*Dimacs, error) {
+	reader := bufio.NewReader(dimacsReader)
+
+	variableSet := map[string]struct{}{}
+	numVariables := 0
+	numClauses := 0
+	var clauses []string
+
+	commentLine := regexp.MustCompile(`^c\s*.*`)
+	headerLine := regexp.MustCompile(`^p cnf\s+\d+\s+\d+\s*`)
+	clauseLine := regexp.MustCompile(`^(-?\d+\s+)+0`)
+	cleanInput := regexp.MustCompile(`\s\s+`)
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("error reading dimacs data: %w", err)
+		}
+		line = strings.TrimSpace(line)
+		line = strings.Trim(line, "\n")
+
+		// ignore comments
+		if commentLine.MatchString(line) {
+			continue
+		}
+
+		// parse header
+		if headerLine.MatchString(line) {
+			line = cleanInput.ReplaceAllString(line, " ")
+			problem := strings.Split(line, " ")
+			if len(problem) != 4 {
+				return nil, fmt.Errorf("invalid statement: (%s). Valid format is p cnf <variables> <clauses>", line)
+			}
+			numVariables, err = strconv.Atoi(problem[2])
+			if err != nil {
+				return nil, fmt.Errorf("invalid number (%s) in statement (%s)", problem[2], line)
+			}
+			numClauses, err = strconv.Atoi(problem[3])
+			if err != nil {
+				return nil, fmt.Errorf("invalid number (%s) in statement (%s)", problem[3], line)
+			}
+			clauses = make([]string, 0, numClauses)
+
+			// parse next line
+			continue
+		}
+
+		// collect clauses
+		if clauseLine.MatchString(line) {
+			if clauses == nil {
+				return nil, fmt.Errorf("invalid dimacs format: missing header 'p cnf <variable> <clauses>'")
+			}
+			line = cleanInput.ReplaceAllString(line, " ")
+			clause := strings.Split(line, " ")
+			if clause[len(clause)-1] != "0" {
+				return nil, fmt.Errorf("invalid clause (%s): does not end with 0", line)
+			}
+			clause = clause[:len(clause)-1]
+			if err := validateClause(clause, numVariables); err != nil {
+				return nil, fmt.Errorf("invalid clause (%s): %w", line, err)
+			}
+
+			// remember variables seen for final validation
+			// to ensure number of variables declared in header
+			// is the same as the number of variables used
+			for _, lit := range clause {
+				lit = strings.TrimPrefix(lit, "-")
+				variableSet[lit] = struct{}{}
+			}
+			clauses = append(clauses, strings.Join(clause, " "))
+
+			// parse next line
+			continue
+		}
+
+		// error out if the instruction is invalid
+		return nil, fmt.Errorf("invalid dimacs command: %s", line)
+	}
+
+	if numVariables == 0 || numClauses == 0 || clauses == nil {
+		return nil, fmt.Errorf("invalid format: no variables or clauses found")
+	}
+
+	if len(clauses) != numClauses {
+		return nil, fmt.Errorf("invalid format: number of clauses in header differ from the total number of clauses")
+	}
+
+	if len(variableSet) != numVariables {
+		return nil, fmt.Errorf("invalid format: number of variables in header differ from the total number of unique variables found in clauses")
+	}
+
+	// create variables
+	variables := make([]string, 0, numVariables)
+	for i := 1; i <= numVariables; i++ {
+		variables = append(variables, fmt.Sprint(i))
+	}
+	return &Dimacs{
+		variables: variables,
+		clauses:   clauses,
+	}, nil
+}
+
+func validateClause(clause []string, numVariables int) error {
+	for _, lit := range clause {
+		litInt, err := strconv.Atoi(lit)
+		if err != nil {
+			return fmt.Errorf("%s is not a number", lit)
+		}
+		if litInt == 0 {
+			return fmt.Errorf("0 is not a valid variable")
+		}
+		if litInt > numVariables || -1*litInt < -1*numVariables {
+			return fmt.Errorf("%s is not a valid variable", lit)
+		}
+	}
+	return nil
+}

--- a/cmd/dimacs/dimacs_constraints.go
+++ b/cmd/dimacs/dimacs_constraints.go
@@ -1,0 +1,68 @@
+package dimacs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/operator-framework/deppy/internal/constraints"
+	"github.com/operator-framework/deppy/internal/entitysource"
+	"github.com/operator-framework/deppy/internal/sat"
+)
+
+var _ constraints.ConstraintGenerator = &ConstraintGenerator{}
+
+type ConstraintGenerator struct {
+	dimacs *Dimacs
+}
+
+func NewDimacsConstraintGenerator(dimacs *Dimacs) *ConstraintGenerator {
+	return &ConstraintGenerator{
+		dimacs: dimacs,
+	}
+}
+
+func (d *ConstraintGenerator) GetVariables(ctx context.Context, querier entitysource.EntityQuerier) ([]sat.Variable, error) {
+	varMap := make(map[entitysource.EntityID]*constraints.Variable, len(d.dimacs.variables))
+	variables := make([]sat.Variable, 0, len(d.dimacs.variables))
+	if err := querier.Iterate(ctx, func(entity *entitysource.Entity) error {
+		variable := constraints.NewVariable(sat.Identifier(entity.ID()))
+		variables = append(variables, variable)
+		varMap[entity.ID()] = variable
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// create constraints out of the clauses
+	for _, clause := range d.dimacs.clauses {
+		terms := strings.Split(clause, " ")
+		if len(terms) == 0 {
+			continue
+		}
+		first := terms[0]
+
+		if len(terms) == 1 {
+			// TODO: check constraints haven't already been added to the variable
+			variable := varMap[entitysource.EntityID(strings.TrimPrefix(first, "-"))]
+			if strings.HasPrefix(first, "-") {
+				variable.AddConstraint(sat.Not())
+			} else {
+				// TODO: is this the right constraint here? (given that its an achoring constraint?)
+				variable.AddConstraint(sat.Mandatory())
+			}
+			continue
+		}
+		for i := 1; i < len(terms); i++ {
+			variable := varMap[entitysource.EntityID(strings.TrimPrefix(first, "-"))]
+			second := terms[i]
+			negSubject := strings.HasPrefix(first, "-")
+			negOperand := strings.HasPrefix(second, "-")
+
+			// TODO: this Or constraint is hacky as hell
+			variable.AddConstraint(sat.Or(sat.Identifier(strings.TrimPrefix(second, "-")), negSubject, negOperand))
+			first = second
+		}
+	}
+
+	return variables, nil
+}

--- a/cmd/dimacs/dimacs_source.go
+++ b/cmd/dimacs/dimacs_source.go
@@ -1,0 +1,24 @@
+package dimacs
+
+import (
+	"github.com/operator-framework/deppy/internal/entitysource"
+)
+
+var _ entitysource.EntitySource = &EntitySource{}
+
+type EntitySource struct {
+	*entitysource.CacheQuerier
+	entitysource.NoContentSource
+}
+
+func NewDimacsEntitySource(dimacs *Dimacs) *EntitySource {
+	entities := make(map[entitysource.EntityID]entitysource.Entity, len(dimacs.Variables()))
+	for _, variable := range dimacs.Variables() {
+		id := entitysource.EntityID(variable)
+		entities[id] = *entitysource.NewEntity(entitysource.EntityID(variable), nil)
+	}
+	return &EntitySource{
+		CacheQuerier:    entitysource.NewCacheQuerier(entities),
+		NoContentSource: entitysource.NoContentSource{},
+	}
+}

--- a/cmd/dimacs/dimacs_test.go
+++ b/cmd/dimacs/dimacs_test.go
@@ -1,0 +1,30 @@
+package dimacs_test
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/operator-framework/deppy/cmd/dimacs"
+)
+
+var _ = Describe("Dimacs", func() {
+	It("should fail if there is no header", func() {
+		problem := "1 2 3 0\n"
+		_, err := dimacs.NewDimacs(bytes.NewReader([]byte(problem)))
+		Expect(err).ToNot(BeNil())
+	})
+	It("should fail if there are no clauses", func() {
+		problem := "p cnf 3 3\n"
+		_, err := dimacs.NewDimacs(bytes.NewReader([]byte(problem)))
+		Expect(err).ToNot(BeNil())
+	})
+	It("should parse valid dimacs", func() {
+		problem := "p cnf 3 1\n1 2 3 0\n"
+		d, err := dimacs.NewDimacs(bytes.NewReader([]byte(problem)))
+		Expect(err).To(BeNil())
+		Expect(d.Variables()).To(Equal([]string{"1", "2", "3"}))
+		Expect(d.Clauses()).To(Equal([]string{"1 2 3"}))
+	})
+})

--- a/cmd/dimacs/solve_suite_test.go
+++ b/cmd/dimacs/solve_suite_test.go
@@ -1,0 +1,13 @@
+package dimacs_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSolve(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Solve Suite")
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -2,13 +2,20 @@ package root
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/deppy/cmd/dimacs"
 )
 
 func NewRootCmd() *cobra.Command {
-	return &cobra.Command{
+	rootCmd := &cobra.Command{
 		Use:   "deppy",
 		Short: "Deppy is an open-source constraint solver framework",
 		Long: `An open-source constraint solver framework written in Go.
 For more information visit https://github.com/operator-framework/deppy`,
 	}
+
+	// add sub-commands
+	rootCmd.AddCommand(dimacs.NewDimacsCommand())
+
+	return rootCmd
 }

--- a/internal/sat/constraints.go
+++ b/internal/sat/constraints.go
@@ -12,9 +12,9 @@ import (
 // particular Variable can appear in a solution.
 type Constraint interface {
 	String(subject Identifier) string
-	Apply(c *logic.C, lm *LitMapping, subject Identifier) z.Lit
-	Order() []Identifier
-	Anchor() bool
+	apply(c *logic.C, lm *litMapping, subject Identifier) z.Lit
+	order() []Identifier
+	anchor() bool
 }
 
 // zeroConstraint is returned by ConstraintOf in error cases.
@@ -26,15 +26,15 @@ func (zeroConstraint) String(subject Identifier) string {
 	return ""
 }
 
-func (zeroConstraint) Apply(c *logic.C, lm *LitMapping, subject Identifier) z.Lit {
+func (zeroConstraint) apply(c *logic.C, lm *litMapping, subject Identifier) z.Lit {
 	return z.LitNull
 }
 
-func (zeroConstraint) Order() []Identifier {
+func (zeroConstraint) order() []Identifier {
 	return nil
 }
 
-func (zeroConstraint) Anchor() bool {
+func (zeroConstraint) anchor() bool {
 	return false
 }
 
@@ -57,15 +57,15 @@ func (constraint mandatory) String(subject Identifier) string {
 	return fmt.Sprintf("%s is mandatory", subject)
 }
 
-func (constraint mandatory) Apply(_ *logic.C, lm *LitMapping, subject Identifier) z.Lit {
+func (constraint mandatory) apply(_ *logic.C, lm *litMapping, subject Identifier) z.Lit {
 	return lm.LitOf(subject)
 }
 
-func (constraint mandatory) Order() []Identifier {
+func (constraint mandatory) order() []Identifier {
 	return nil
 }
 
-func (constraint mandatory) Anchor() bool {
+func (constraint mandatory) anchor() bool {
 	return true
 }
 
@@ -81,21 +81,21 @@ func (constraint prohibited) String(subject Identifier) string {
 	return fmt.Sprintf("%s is prohibited", subject)
 }
 
-func (constraint prohibited) Apply(c *logic.C, lm *LitMapping, subject Identifier) z.Lit {
+func (constraint prohibited) apply(c *logic.C, lm *litMapping, subject Identifier) z.Lit {
 	return lm.LitOf(subject).Not()
 }
 
-func (constraint prohibited) Order() []Identifier {
+func (constraint prohibited) order() []Identifier {
 	return nil
 }
 
-func (constraint prohibited) Anchor() bool {
+func (constraint prohibited) anchor() bool {
 	return false
 }
 
 // Prohibited returns a Constraint that will reject any solution that
 // contains a particular Variable. Callers may also decide to omit
-// an Variable from input to Solve rather than Apply such a
+// an Variable from input to Solve rather than apply such a
 // Constraint.
 func Prohibited() Constraint {
 	return prohibited{}
@@ -114,7 +114,7 @@ func (constraint dependency) String(subject Identifier) string {
 	return fmt.Sprintf("%s requires at least one of %s", subject, strings.Join(s, ", "))
 }
 
-func (constraint dependency) Apply(c *logic.C, lm *LitMapping, subject Identifier) z.Lit {
+func (constraint dependency) apply(c *logic.C, lm *litMapping, subject Identifier) z.Lit {
 	m := lm.LitOf(subject).Not()
 	for _, each := range constraint {
 		m = c.Or(m, lm.LitOf(each))
@@ -122,11 +122,11 @@ func (constraint dependency) Apply(c *logic.C, lm *LitMapping, subject Identifie
 	return m
 }
 
-func (constraint dependency) Order() []Identifier {
+func (constraint dependency) order() []Identifier {
 	return constraint
 }
 
-func (constraint dependency) Anchor() bool {
+func (constraint dependency) anchor() bool {
 	return false
 }
 
@@ -145,15 +145,15 @@ func (constraint conflict) String(subject Identifier) string {
 	return fmt.Sprintf("%s conflicts with %s", subject, constraint)
 }
 
-func (constraint conflict) Apply(c *logic.C, lm *LitMapping, subject Identifier) z.Lit {
+func (constraint conflict) apply(c *logic.C, lm *litMapping, subject Identifier) z.Lit {
 	return c.Or(lm.LitOf(subject).Not(), lm.LitOf(Identifier(constraint)).Not())
 }
 
-func (constraint conflict) Order() []Identifier {
+func (constraint conflict) order() []Identifier {
 	return nil
 }
 
-func (constraint conflict) Anchor() bool {
+func (constraint conflict) anchor() bool {
 	return false
 }
 
@@ -177,7 +177,7 @@ func (constraint leq) String(subject Identifier) string {
 	return fmt.Sprintf("%s permits at most %d of %s", subject, constraint.n, strings.Join(s, ", "))
 }
 
-func (constraint leq) Apply(c *logic.C, lm *LitMapping, subject Identifier) z.Lit {
+func (constraint leq) apply(c *logic.C, lm *litMapping, subject Identifier) z.Lit {
 	ms := make([]z.Lit, len(constraint.ids))
 	for i, each := range constraint.ids {
 		ms[i] = lm.LitOf(each)
@@ -185,11 +185,11 @@ func (constraint leq) Apply(c *logic.C, lm *LitMapping, subject Identifier) z.Li
 	return c.CardSort(ms).Leq(constraint.n)
 }
 
-func (constraint leq) Order() []Identifier {
+func (constraint leq) order() []Identifier {
 	return nil
 }
 
-func (constraint leq) Anchor() bool {
+func (constraint leq) anchor() bool {
 	return false
 }
 

--- a/internal/sat/constraints_test.go
+++ b/internal/sat/constraints_test.go
@@ -33,7 +33,7 @@ func TestOrder(t *testing.T) {
 		},
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
-			assert.Equal(t, tt.Expected, tt.Constraint.Order())
+			assert.Equal(t, tt.Expected, tt.Constraint.order())
 		})
 	}
 }

--- a/internal/sat/search.go
+++ b/internal/sat/search.go
@@ -22,7 +22,7 @@ type guess struct {
 
 type search struct {
 	s                      inter.S
-	lits                   *LitMapping
+	lits                   *litMapping
 	assumptions            map[z.Lit]struct{} // set of assumed lits - duplicates guess stack - for fast lookup
 	guesses                []guess            // stack of assumed guesses
 	headChoice, tailChoice *choice            // deque of unmade choices
@@ -59,7 +59,7 @@ func (h *search) PushGuess() {
 	variable := h.lits.VariableOf(g.m)
 	for _, constraint := range variable.Constraints() {
 		var ms []z.Lit
-		for _, dependency := range constraint.Order() {
+		for _, dependency := range constraint.order() {
 			ms = append(ms, h.lits.LitOf(dependency))
 		}
 		if len(ms) > 0 {

--- a/internal/sat/solve.go
+++ b/internal/sat/solve.go
@@ -35,7 +35,7 @@ type Solver interface {
 
 type solver struct {
 	g      inter.S
-	litMap *LitMapping
+	litMap *litMapping
 	tracer Tracer
 	buffer []z.Lit
 }
@@ -78,7 +78,7 @@ func (s *solver) Solve(ctx context.Context) (result []Variable, err error) {
 	// push a new test scope with the baseline assumptions, to prevent them from being cleared during search
 	outcome, _ := s.g.Test(nil)
 	if outcome != satisfiable && outcome != unsatisfiable {
-		// searcher for solutions in input Order, so that preferences
+		// searcher for solutions in input order, so that preferences
 		// can be taken into acount (i.e. prefer one catalog to another)
 		outcome, assumptions, aset = (&search{s: s.g, lits: s.litMap, tracer: s.tracer}).Do(context.Background(), assumptions)
 	}

--- a/internal/sat/solve_test.go
+++ b/internal/sat/solve_test.go
@@ -196,7 +196,7 @@ func TestSolve(t *testing.T) {
 			},
 		},
 		{
-			Name: "irrelevant dependencies don't influence search Order",
+			Name: "irrelevant dependencies don't influence search order",
 			Variables: []Variable{
 				variable("a", Dependency("x", "y")),
 				variable("b", Mandatory(), Dependency("y", "x")),
@@ -314,7 +314,7 @@ func TestSolve(t *testing.T) {
 			}
 
 			// Failed constraints are sorted in lexically
-			// increasing Order of the identifier of the
+			// increasing order of the identifier of the
 			// constraint's variable, with ties broken
 			// in favor of the constraint that appears
 			// earliest in the variable's list of

--- a/internal/sat/variable.go
+++ b/internal/sat/variable.go
@@ -21,7 +21,7 @@ type Variable interface {
 	// this Variable among all other Variables in a given
 	// problem.
 	Identifier() Identifier
-	// Constraints returns the set of constraints that Apply to
+	// Constraints returns the set of constraints that apply to
 	// this Variable.
 	Constraints() []Constraint
 }

--- a/internal/solver/solver.go
+++ b/internal/solver/solver.go
@@ -10,6 +10,9 @@ import (
 
 var _ Solver = &DeppySolver{}
 
+// TODO: should be disambiguate between solver errors due to constraints
+//       and other generic errors (e.g. entity source not reachable, etc.)
+
 // Solution is returned by the Solver when a solution could be found
 // it can be queried by EntityID to see if the entity was selected (true) or not (false)
 // by the solver


### PR DESCRIPTION
This PR adds a deppy command for solving arbitrary sat problems described in dimacs format

**Note**: to make dimacs work I had to change the definition of sat.Constraint to export the previously unexported methods (e.g. anchor, apply, etc.), so that I could define my own constraint type. I think we need to figure out a way to build these constraints with And, Or, Not top level constraints.