### PR TITLE
Deppy Framework (7/7): sudoku deppy command

### DIFF
--- a/cmd/dimacs/dimacs_source.go
+++ b/cmd/dimacs/dimacs_source.go
@@ -8,7 +8,7 @@ var _ entitysource.EntitySource = &EntitySource{}
 
 type EntitySource struct {
 	*entitysource.CacheQuerier
-	entitysource.NoContentSource
+	entitysource.EntityContentGetter
 }
 
 func NewDimacsEntitySource(dimacs *Dimacs) *EntitySource {
@@ -17,8 +17,9 @@ func NewDimacsEntitySource(dimacs *Dimacs) *EntitySource {
 		id := entitysource.EntityID(variable)
 		entities[id] = *entitysource.NewEntity(entitysource.EntityID(variable), nil)
 	}
+
 	return &EntitySource{
-		CacheQuerier:    entitysource.NewCacheQuerier(entities),
-		NoContentSource: entitysource.NoContentSource{},
+		CacheQuerier:        entitysource.NewCacheQuerier(entities),
+		EntityContentGetter: entitysource.NoContentSource(),
 	}
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -3,6 +3,8 @@ package root
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/operator-framework/deppy/cmd/sudoku"
+
 	"github.com/operator-framework/deppy/cmd/dimacs"
 )
 
@@ -16,6 +18,7 @@ For more information visit https://github.com/operator-framework/deppy`,
 
 	// add sub-commands
 	rootCmd.AddCommand(dimacs.NewDimacsCommand())
+	rootCmd.AddCommand(sudoku.NewSudokuCommand())
 
 	return rootCmd
 }

--- a/cmd/sudoku/cmd.go
+++ b/cmd/sudoku/cmd.go
@@ -1,0 +1,60 @@
+package sudoku
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/deppy/internal/constraints"
+	"github.com/operator-framework/deppy/internal/entitysource"
+	"github.com/operator-framework/deppy/internal/solver"
+)
+
+func NewSudokuCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "sudoku",
+		Short: "Returns a solved sudoku board",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return solve()
+		},
+	}
+}
+
+func solve() error {
+	// build solver
+	sudoku := NewSudoku()
+	so, err := solver.NewDeppySolver(entitysource.NewGroup(sudoku), constraints.NewConstraintAggregator(sudoku))
+	if err != nil {
+		return err
+	}
+
+	// get solution
+	solution, err := so.Solve(context.Background())
+	if err != nil {
+		fmt.Println("no solution found")
+	} else {
+		for row := 0; row < 9; row++ {
+			for col := 0; col < 9; col++ {
+				found := false
+				for n := 0; n < 9; n++ {
+					id := GetID(row, col, n)
+					if solution[id] {
+						fmt.Printf("%d", n+1)
+						found = true
+						break
+					}
+				}
+				if !found {
+					fmt.Printf(" ")
+				}
+				if col != 8 {
+					fmt.Printf(" ")
+				}
+			}
+			fmt.Printf("\n")
+		}
+	}
+
+	return nil
+}

--- a/cmd/sudoku/sudoku.go
+++ b/cmd/sudoku/sudoku.go
@@ -1,0 +1,138 @@
+package sudoku
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/operator-framework/deppy/internal/constraints"
+	"github.com/operator-framework/deppy/internal/entitysource"
+	"github.com/operator-framework/deppy/internal/sat"
+)
+
+var _ entitysource.EntitySource = &Sudoku{}
+var _ constraints.ConstraintGenerator = &Sudoku{}
+
+type Sudoku struct {
+	*entitysource.CacheQuerier
+	entitysource.EntityContentGetter
+}
+
+func GetID(row int, col int, num int) entitysource.EntityID {
+	n := num
+	n += col * 9
+	n += row * 81
+	return entitysource.EntityID(fmt.Sprintf("%03d", n))
+}
+
+func NewSudoku() *Sudoku {
+	var entities = make(map[entitysource.EntityID]entitysource.Entity, 9*9*9)
+	for row := 0; row < 9; row++ {
+		for col := 0; col < 9; col++ {
+			for num := 0; num < 9; num++ {
+				id := GetID(row, col, num)
+				entities[id] = *entitysource.NewEntity(id, map[string]string{
+					"row": strconv.Itoa(row),
+					"col": strconv.Itoa(col),
+					"num": strconv.Itoa(num),
+				})
+			}
+		}
+	}
+	return &Sudoku{
+		CacheQuerier:        entitysource.NewCacheQuerier(entities),
+		EntityContentGetter: entitysource.NoContentSource(),
+	}
+}
+
+func (s Sudoku) GetVariables(ctx context.Context, querier entitysource.EntityQuerier) ([]sat.Variable, error) {
+	// adapted from: https://github.com/go-air/gini/blob/871d828a26852598db2b88f436549634ba9533ff/sudoku_test.go#L10
+	variables := make(map[sat.Identifier]*constraints.Variable, 0)
+	inorder := make([]sat.Variable, 0)
+	rand.Seed(time.Now().UnixNano())
+
+	// create variables for all number in all positions of the board
+	for row := 0; row < 9; row++ {
+		for col := 0; col < 9; col++ {
+			for n := 0; n < 9; n++ {
+				variable := constraints.NewVariable(sat.Identifier(GetID(row, col, n)))
+				variables[variable.Identifier()] = variable
+				inorder = append(inorder, variable)
+			}
+		}
+	}
+
+	// add a clause stating that every position on the board has a number
+	for row := 0; row < 9; row++ {
+		for col := 0; col < 9; col++ {
+			ids := make([]sat.Identifier, 9)
+			for n := 0; n < 9; n++ {
+				ids[n] = sat.Identifier(GetID(row, col, n))
+			}
+			// randomize order to create new sudoku boards every run
+			rand.Shuffle(len(ids), func(i, j int) { ids[i], ids[j] = ids[j], ids[i] })
+
+			// create clause that the particular position has a number
+			varID := sat.Identifier(fmt.Sprintf("%d-%d has a number", row, col))
+			variable := constraints.NewVariable(varID, sat.Mandatory(), sat.Dependency(ids...))
+			variables[varID] = variable
+			inorder = append(inorder, variable)
+		}
+	}
+
+	// every row has unique numbers
+	for n := 0; n < 9; n++ {
+		for row := 0; row < 9; row++ {
+			for colA := 0; colA < 9; colA++ {
+				idA := sat.Identifier(GetID(row, colA, n))
+				variable := variables[idA]
+				for colB := colA + 1; colB < 9; colB++ {
+					variable.AddConstraint(sat.Conflict(sat.Identifier(GetID(row, colB, n))))
+				}
+			}
+		}
+	}
+
+	// every column has unique numbers
+	for n := 0; n < 9; n++ {
+		for col := 0; col < 9; col++ {
+			for rowA := 0; rowA < 9; rowA++ {
+				idA := sat.Identifier(GetID(rowA, col, n))
+				variable := variables[idA]
+				for rowB := rowA + 1; rowB < 9; rowB++ {
+					variable.AddConstraint(sat.Conflict(sat.Identifier(GetID(rowB, col, n))))
+				}
+			}
+		}
+	}
+
+	// function adding constraints stating that every box on the board
+	// rooted at x, y has unique numbers
+	var box = func(x, y int) {
+		// all offsets w.r.t. root x,y
+		offs := []struct{ x, y int }{{0, 0}, {0, 1}, {0, 2}, {1, 0}, {1, 1}, {1, 2}, {2, 0}, {2, 1}, {2, 2}}
+		// all numbers
+		for n := 0; n < 9; n++ {
+			for i, offA := range offs {
+				idA := sat.Identifier(GetID(x+offA.x, y+offA.y, n))
+				variable := variables[idA]
+				for j := i + 1; j < len(offs); j++ {
+					offB := offs[j]
+					idB := sat.Identifier(GetID(x+offB.x, y+offB.y, n))
+					variable.AddConstraint(sat.Conflict(idB))
+				}
+			}
+		}
+	}
+
+	// every box has unique numbers
+	for x := 0; x < 9; x += 3 {
+		for y := 0; y < 9; y += 3 {
+			box(x, y)
+		}
+	}
+
+	return inorder, nil
+}

--- a/internal/entitysource/no_content.go
+++ b/internal/entitysource/no_content.go
@@ -2,10 +2,14 @@ package entitysource
 
 import "context"
 
-var _ EntityContentGetter = &NoContentSource{}
+var _ EntityContentGetter = &noContentSource{}
 
-type NoContentSource struct{}
+type noContentSource struct{}
 
-func (n *NoContentSource) GetContent(_ context.Context, _ EntityID) (interface{}, error) {
+func NoContentSource() EntityContentGetter {
+	return &noContentSource{}
+}
+
+func (n *noContentSource) GetContent(_ context.Context, _ EntityID) (interface{}, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This PR adds the `sudoku` sub-command to deppy cli. It will spit out a solved sudoku board.

**Note**: sudoku seems to have a bug in it where some of the boards have gaps in them. I'm really not sure where this issue is coming from, especially since it was actually pretty easy to model the constraints using the available constraint definitions...