### PR TITLE
move NotSatisfiable error definition out of internal

### DIFF
--- a/internal/solver/solve.go
+++ b/internal/solver/solve.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/go-air/gini"
 	"github.com/go-air/gini/inter"
@@ -14,22 +13,6 @@ import (
 )
 
 var ErrIncomplete = errors.New("cancelled before a solution could be found")
-
-// NotSatisfiable is an error composed of a minimal set of applied
-// constraints that is sufficient to make a solution impossible.
-type NotSatisfiable []deppy.AppliedConstraint
-
-func (e NotSatisfiable) Error() string {
-	const msg = "constraints not satisfiable"
-	if len(e) == 0 {
-		return msg
-	}
-	s := make([]string, len(e))
-	for i, a := range e {
-		s[i] = a.String()
-	}
-	return fmt.Sprintf("%s: %s", msg, strings.Join(s, ", "))
-}
 
 type Solver interface {
 	Solve(context.Context) ([]deppy.Variable, error)
@@ -114,7 +97,7 @@ func (s *solver) Solve(ctx context.Context) (result []deppy.Variable, err error)
 		// after optimizing for cardinality.
 		return nil, fmt.Errorf("unexpected internal error")
 	case unsatisfiable:
-		return nil, NotSatisfiable(s.litMap.Conflicts(s.g))
+		return nil, deppy.NotSatisfiable(s.litMap.Conflicts(s.g))
 	}
 
 	return nil, ErrIncomplete

--- a/internal/solver/solve_test.go
+++ b/internal/solver/solve_test.go
@@ -43,7 +43,7 @@ func variable(id deppy.Identifier, constraints ...deppy.Constraint) deppy.Variab
 func TestNotSatisfiableError(t *testing.T) {
 	type tc struct {
 		Name   string
-		Error  NotSatisfiable
+		Error  deppy.NotSatisfiable
 		String string
 	}
 
@@ -55,11 +55,11 @@ func TestNotSatisfiableError(t *testing.T) {
 		{
 			Name:   "empty",
 			String: "constraints not satisfiable",
-			Error:  NotSatisfiable{},
+			Error:  deppy.NotSatisfiable{},
 		},
 		{
 			Name: "single failure",
-			Error: NotSatisfiable{
+			Error: deppy.NotSatisfiable{
 				deppy.AppliedConstraint{
 					Variable:   variable("a", constraint.Mandatory()),
 					Constraint: constraint.Mandatory(),
@@ -70,7 +70,7 @@ func TestNotSatisfiableError(t *testing.T) {
 		},
 		{
 			Name: "multiple failures",
-			Error: NotSatisfiable{
+			Error: deppy.NotSatisfiable{
 				deppy.AppliedConstraint{
 					Variable:   variable("a", constraint.Mandatory()),
 					Constraint: constraint.Mandatory(),
@@ -114,7 +114,7 @@ func TestSolve(t *testing.T) {
 		{
 			Name:      "both mandatory and prohibited produce error",
 			Variables: []deppy.Variable{variable("a", constraint.Mandatory(), constraint.Prohibited())},
-			Error: NotSatisfiable{
+			Error: deppy.NotSatisfiable{
 				{
 					Variable:   variable("a", constraint.Mandatory(), constraint.Prohibited()),
 					Constraint: constraint.Mandatory(),
@@ -184,7 +184,7 @@ func TestSolve(t *testing.T) {
 				variable("a", constraint.Mandatory()),
 				variable("b", constraint.Mandatory(), constraint.Conflict("a")),
 			},
-			Error: NotSatisfiable{
+			Error: deppy.NotSatisfiable{
 				{
 					Variable:   variable("a", constraint.Mandatory()),
 					Constraint: constraint.Mandatory(),
@@ -216,7 +216,7 @@ func TestSolve(t *testing.T) {
 				variable("x", constraint.Mandatory()),
 				variable("y", constraint.Mandatory()),
 			},
-			Error: NotSatisfiable{
+			Error: deppy.NotSatisfiable{
 				{
 					Variable:   variable("a", constraint.Mandatory(), constraint.Dependency("x", "y"), constraint.AtMost(1, "x", "y")),
 					Constraint: constraint.AtMost(1, "x", "y"),
@@ -313,7 +313,7 @@ func TestSolve(t *testing.T) {
 			// in favor of the constraint that appears
 			// earliest in the variable's list of
 			// constraints.
-			var ns NotSatisfiable
+			var ns deppy.NotSatisfiable
 			if errors.As(err, &ns) {
 				sort.SliceStable(ns, func(i, j int) bool {
 					if ns[i].Variable.Identifier() != ns[j].Variable.Identifier() {

--- a/pkg/deppy/api.go
+++ b/pkg/deppy/api.go
@@ -1,9 +1,28 @@
 package deppy
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/go-air/gini/logic"
 	"github.com/go-air/gini/z"
 )
+
+// NotSatisfiable is an error composed of a minimal set of applied
+// constraints that is sufficient to make a solution impossible.
+type NotSatisfiable []AppliedConstraint
+
+func (e NotSatisfiable) Error() string {
+	const msg = "constraints not satisfiable"
+	if len(e) == 0 {
+		return msg
+	}
+	s := make([]string, len(e))
+	for i, a := range e {
+		s[i] = a.String()
+	}
+	return fmt.Sprintf("%s: %s", msg, strings.Join(s, ", "))
+}
 
 // Identifier values uniquely identify particular Variables within
 // the input to a single call to Solve.


### PR DESCRIPTION
Moves the `NotSatisfiable` error out of the internal package. It's important to make this error usable by users, for instance, to improve the way resolution errors are communicated

Signed-off-by: perdasilva <perdasilva@redhat.com>