### PR TITLE
Refactor solver solution struct

### DIFF
--- a/cmd/dimacs/cmd.go
+++ b/cmd/dimacs/cmd.go
@@ -59,13 +59,13 @@ func solve(path string) error {
 	}
 
 	// get solution
-	solution, err := so.Solve(context.Background())
+	solution, err := so.Solve(context.Background(), solver.AddAllVariablesToSolution())
 	if err != nil {
 		fmt.Printf("no solution found: %s\n", err)
 	} else {
 		fmt.Println("solution found:")
-		for entityID, selected := range solution {
-			fmt.Printf("%s = %t\n", entityID, selected)
+		for _, variable := range solution.AllVariables() {
+			fmt.Printf("%s = %t\n", variable.Identifier(), solution.IsSelected(variable.Identifier()))
 		}
 	}
 

--- a/cmd/sudoku/cmd.go
+++ b/cmd/sudoku/cmd.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/operator-framework/deppy/pkg/deppy"
+
 	"github.com/operator-framework/deppy/pkg/deppy/solver"
 )
 
@@ -32,12 +34,16 @@ func solve() error {
 	if err != nil {
 		fmt.Println("no solution found")
 	} else {
+		selected := map[deppy.Identifier]struct{}{}
+		for _, variable := range solution.SelectedVariables() {
+			selected[variable.Identifier()] = struct{}{}
+		}
 		for row := 0; row < 9; row++ {
 			for col := 0; col < 9; col++ {
 				found := false
 				for n := 0; n < 9; n++ {
 					id := GetID(row, col, n)
-					if solution[id] {
+					if _, ok := selected[id]; ok {
 						fmt.Printf("%d", n+1)
 						found = true
 						break

--- a/pkg/deppy/solver/solver.go
+++ b/pkg/deppy/solver/solver.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"context"
+	"errors"
 
 	"github.com/operator-framework/deppy/internal/solver"
 	"github.com/operator-framework/deppy/pkg/deppy"
@@ -11,10 +12,67 @@ import (
 // TODO: should disambiguate between solver errors due to constraints
 //       and other generic errors (e.g. entity source not reachable, etc.)
 
-// Solution is returned by the Solver when a solution could be found
-// it can be queried by Identifier to see if the entity was selected (true) or not (false)
-// by the solver
-type Solution map[deppy.Identifier]bool
+// Solution is returned by the Solver when the internal solver executed successfully.
+// A successful execution of the solver can still end in an error when no solution can
+// be found.
+type Solution struct {
+	err       deppy.NotSatisfiable
+	selection map[deppy.Identifier]deppy.Variable
+	variables []deppy.Variable
+}
+
+// Error returns the resolution error in case the problem is unsat
+// on successful resolution, it will return nil
+func (s *Solution) Error() error {
+	return s.err
+}
+
+// SelectedVariables returns the variables that were selected by the solver
+// as part of the solution
+func (s *Solution) SelectedVariables() map[deppy.Identifier]deppy.Variable {
+	return s.selection
+}
+
+// IsSelected returns true if the variable identified by the identifier was selected
+// in the solution by the resolver. It will return false otherwise.
+func (s *Solution) IsSelected(identifier deppy.Identifier) bool {
+	_, ok := s.selection[identifier]
+	return ok
+}
+
+// AllVariables returns all the variables that were considered by the solver to obtain (or not)
+// a solution. Note: This is only be present if the AddAllVariablesToSolution option is passed in to the
+// Solve call that generated the solution.
+func (s *Solution) AllVariables() []deppy.Variable {
+	return s.variables
+}
+
+type solutionOptions struct {
+	addVariablesToSolution bool
+}
+
+func (s *solutionOptions) apply(options ...Option) *solutionOptions {
+	for _, applyOption := range options {
+		applyOption(s)
+	}
+	return s
+}
+
+func defaultSolutionOptions() *solutionOptions {
+	return &solutionOptions{
+		addVariablesToSolution: false,
+	}
+}
+
+type Option func(solutionOptions *solutionOptions)
+
+// AddAllVariablesToSolution is a Solve option that instructs the solver to include
+// all the variables considered to the Solution it produces
+func AddAllVariablesToSolution() Option {
+	return func(solutionOptions *solutionOptions) {
+		solutionOptions.addVariablesToSolution = true
+	}
+}
 
 // DeppySolver is a simple solver implementation that takes an entity source group and a constraint aggregator
 // to produce a Solution (or error if no solution can be found)
@@ -30,7 +88,9 @@ func NewDeppySolver(entitySource input.EntitySource, variableSource input.Variab
 	}, nil
 }
 
-func (d DeppySolver) Solve(ctx context.Context) (Solution, error) {
+func (d DeppySolver) Solve(ctx context.Context, options ...Option) (*Solution, error) {
+	solutionOpts := defaultSolutionOptions().apply(options...)
+
 	vars, err := d.variableSource.GetVariables(ctx, d.entitySource)
 	if err != nil {
 		return nil, err
@@ -42,20 +102,25 @@ func (d DeppySolver) Solve(ctx context.Context) (Solution, error) {
 	}
 
 	selection, err := satSolver.Solve(ctx)
-	if err != nil {
+	if err != nil && !errors.As(err, &deppy.NotSatisfiable{}) {
 		return nil, err
 	}
 
-	solution := Solution{}
-	for _, variable := range vars {
-		if entity := d.entitySource.Get(ctx, variable.Identifier()); entity != nil {
-			solution[entity.Identifier()] = false
-		}
-	}
+	selectionMap := map[deppy.Identifier]deppy.Variable{}
 	for _, variable := range selection {
-		if entity := d.entitySource.Get(ctx, variable.Identifier()); entity != nil {
-			solution[entity.Identifier()] = true
-		}
+		selectionMap[variable.Identifier()] = variable
 	}
+
+	solution := &Solution{selection: selectionMap}
+	if err != nil {
+		unsatError := deppy.NotSatisfiable{}
+		errors.As(err, &unsatError)
+		solution.err = unsatError
+	}
+
+	if solutionOpts.addVariablesToSolution {
+		solution.variables = vars
+	}
+
 	return solution, nil
 }


### PR DESCRIPTION
This PR refactors the `Solution` struct to be a little more helpful. It now returns returns the resolution error (if any), the selected variables, given a variable ID you can see whether it has been selected, and with an option, all variables used in the resolution can also be returned.

Signed-off-by: perdasilva <perdasilva@redhat.com>