### PR TITLE
[Pipeline pt2] Introduce router and routes for events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-air/gini v1.0.4
+	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo/v2 v2.3.1
 	github.com/onsi/gomega v1.22.1
 	github.com/spf13/cobra v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/go-air/gini v1.0.4/go.mod h1:dd8RvT1xcv6N1da33okvBd8DhMh1/A4siGy6ErjT
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/pkg/deppy/pipeline/api.go
+++ b/pkg/deppy/pipeline/api.go
@@ -20,6 +20,10 @@ type EventHeader interface {
 	Metadata() EventMetadata
 }
 
+type EventSource interface {
+	EventSourceID() EventSourceID
+}
+
 type EventIDProvider interface {
 	NextEventID() EventID
 }

--- a/pkg/deppy/pipeline/api.go
+++ b/pkg/deppy/pipeline/api.go
@@ -1,0 +1,49 @@
+package pipeline
+
+import (
+	"time"
+)
+
+type EventSourceID string
+
+type EventType string
+type EventID string
+type EventMetadata map[string]string
+
+type EventHeader interface {
+	EventID() EventID
+	Creator() EventSourceID
+	Sender() EventSourceID
+	Receiver() EventSourceID
+	IsBroadcastEvent() bool
+	CreationTime() time.Time
+	Metadata() EventMetadata
+}
+
+type EventIDProvider interface {
+	NextEventID() EventID
+}
+
+type Event interface {
+	Header() EventHeader
+	Broadcast()
+	Route(dest EventSourceID)
+	String() string
+}
+
+type DataEvent[D interface{}] interface {
+	Event
+	Data() D
+	Copy() DataEvent[D]
+}
+
+type ErrorEvent interface {
+	Event
+	Error() error
+	Copy() ErrorEvent
+}
+
+type EventFactory[I interface{}] interface {
+	NewErrorEvent(err error) ErrorEvent
+	NewDataEvent(data I) DataEvent[I]
+}

--- a/pkg/deppy/pipeline/api.go
+++ b/pkg/deppy/pipeline/api.go
@@ -22,6 +22,7 @@ type EventHeader interface {
 
 type EventSource interface {
 	EventSourceID() EventSourceID
+	IngressCapacity() int
 }
 
 type EventIDProvider interface {

--- a/pkg/deppy/pipeline/event/event.go
+++ b/pkg/deppy/pipeline/event/event.go
@@ -1,0 +1,128 @@
+package event
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline"
+)
+
+var _ pipeline.Event = &event{}
+
+type event struct {
+	EventHeader *eventHeader `json:"header"`
+	lock        sync.RWMutex
+}
+
+func newEvent(header *eventHeader) *event {
+	return &event{
+		EventHeader: header,
+		lock:        sync.RWMutex{},
+	}
+}
+
+func (e *event) Header() pipeline.EventHeader {
+	return e.EventHeader
+}
+
+func (e *event) Broadcast() {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.EventHeader.broadcast()
+}
+
+func (e *event) Route(dest pipeline.EventSourceID) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.EventHeader.route(dest)
+}
+
+func (e *event) String() string {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	bytes, err := json.Marshal(e)
+	if err != nil {
+		return string(e.EventHeader.EventID())
+	}
+	return string(bytes)
+}
+
+var _ pipeline.DataEvent[interface{}] = &dataEvent[interface{}]{}
+
+type dataEvent[D interface{}] struct {
+	*event
+	EventData D `json:"data"`
+}
+
+func (p *dataEvent[I]) Header() pipeline.EventHeader {
+	return p.EventHeader
+}
+
+func (p *dataEvent[I]) Data() I {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.EventData
+}
+
+func (p *dataEvent[I]) String() string {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	bytes, err := json.Marshal(p)
+	if err != nil {
+		return string(p.EventHeader.EventID())
+	}
+	return string(bytes)
+}
+
+func (p *dataEvent[I]) Copy() pipeline.DataEvent[I] {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return &dataEvent[I]{
+		event: &event{
+			EventHeader: p.EventHeader.copy(),
+			lock:        sync.RWMutex{},
+		},
+		EventData: p.EventData,
+	}
+}
+
+var _ pipeline.ErrorEvent = &errorEvent{}
+
+type errorEvent struct {
+	*event
+	EventError error `json:"error"`
+}
+
+func (e *errorEvent) Header() pipeline.EventHeader {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+	return e.EventHeader
+}
+
+func (e *errorEvent) Error() error {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+	return e.EventError
+}
+
+func (e *errorEvent) String() string {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	bytes, err := json.Marshal(e)
+	if err != nil {
+		return string(e.EventHeader.EventID())
+	}
+	return string(bytes)
+}
+
+func (e *errorEvent) Copy() pipeline.ErrorEvent {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+	return &errorEvent{
+		event: &event{
+			EventHeader: e.EventHeader.copy(),
+			lock:        sync.RWMutex{},
+		},
+		EventError: e.EventError,
+	}
+}

--- a/pkg/deppy/pipeline/event/event_test.go
+++ b/pkg/deppy/pipeline/event/event_test.go
@@ -1,0 +1,103 @@
+package event_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline"
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline/event"
+)
+
+var _ pipeline.EventIDProvider = &fakeCustomEventIDProvider{}
+
+type fakeCustomEventIDProvider struct {
+	fn func() pipeline.EventID
+}
+
+func (f fakeCustomEventIDProvider) NextEventID() pipeline.EventID {
+	return f.fn()
+}
+
+func TestEventFactory_NewDataEvent(t *testing.T) {
+	factory := event.NewEventFactory[int]("node")
+	dataEvent := factory.NewDataEvent(1)
+	assert.Equal(t, 1, dataEvent.Data())
+	assert.Equal(t, pipeline.EventSourceID("node"), dataEvent.Header().Creator())
+	assert.Nil(t, dataEvent.Header().Metadata())
+	assert.Empty(t, dataEvent.Header().Receiver())
+	assert.False(t, dataEvent.Header().IsBroadcastEvent())
+	assert.Equal(t, pipeline.EventSourceID("node"), dataEvent.Header().Sender())
+	assert.NotNil(t, dataEvent.Header().CreationTime())
+	assert.NotNil(t, dataEvent.Header().EventID())
+}
+
+func TestEventFactory_NewErrorEvent(t *testing.T) {
+	factory := event.NewEventFactory[int]("node")
+	errorEvent := factory.NewErrorEvent(fmt.Errorf("some error"))
+	assert.Equal(t, fmt.Errorf("some error"), errorEvent.Error())
+	assert.Equal(t, pipeline.EventSourceID("node"), errorEvent.Header().Creator())
+	assert.Nil(t, errorEvent.Header().Metadata())
+	assert.Empty(t, errorEvent.Header().Receiver())
+	assert.False(t, errorEvent.Header().IsBroadcastEvent())
+	assert.Equal(t, pipeline.EventSourceID("node"), errorEvent.Header().Sender())
+	assert.NotNil(t, errorEvent.Header().CreationTime())
+	assert.NotNil(t, errorEvent.Header().EventID())
+}
+
+func TestEventFactory_NewEventWithMetadata(t *testing.T) {
+	eventMetadata := pipeline.EventMetadata{"meta": "data"}
+	factory := event.NewEventFactory[int]("node", event.WithEventMetadata[int](eventMetadata))
+	dataEvent := factory.NewDataEvent(1)
+	errorEvent := factory.NewErrorEvent(fmt.Errorf("some error"))
+	assert.Equal(t, eventMetadata, dataEvent.Header().Metadata())
+	assert.Equal(t, eventMetadata, errorEvent.Header().Metadata())
+}
+
+func TestEventFactory_NewEventWithCustomEventIDProvider(t *testing.T) {
+	staticEventID := pipeline.EventID("1")
+	eventIDProvider := fakeCustomEventIDProvider{
+		fn: func() pipeline.EventID {
+			return staticEventID
+		},
+	}
+	factory := event.NewEventFactory[int]("node", event.WithEventIDProvider[int](eventIDProvider))
+	dataEvent := factory.NewDataEvent(1)
+	errorEvent := factory.NewErrorEvent(fmt.Errorf("some error"))
+	assert.Equal(t, staticEventID, dataEvent.Header().EventID())
+	assert.Equal(t, staticEventID, errorEvent.Header().EventID())
+}
+
+func TestEventFactory_Broadcast(t *testing.T) {
+	factory := event.NewEventFactory[int]("node")
+	evt := factory.NewDataEvent(1)
+	evt.Broadcast()
+	assert.True(t, evt.Header().IsBroadcastEvent())
+}
+
+func TestEventFactory_Route(t *testing.T) {
+	factory := event.NewEventFactory[int]("node")
+	evt := factory.NewDataEvent(1)
+	evt.Route("node2")
+	assert.Equal(t, pipeline.EventSourceID("node"), evt.Header().Sender())
+	assert.Equal(t, pipeline.EventSourceID("node2"), evt.Header().Receiver())
+}
+
+func TestEventFactory_JSONSerializable(t *testing.T) {
+	staticEventID := pipeline.EventID("1")
+	eventIDProvider := fakeCustomEventIDProvider{
+		fn: func() pipeline.EventID {
+			return staticEventID
+		},
+	}
+	factory := event.NewEventFactory[int]("node", event.WithEventIDProvider[int](eventIDProvider))
+	evt := factory.NewDataEvent(1)
+	bytes, err := json.Marshal(evt)
+	assert.Nil(t, err)
+	regExp, err := regexp.Compile(`\{"header":\{"eventID":"1","creatorEventSourceID":"node","sender":"node","broadcast":false,"creationTime":"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\..*"},"data":1}`)
+	assert.Nil(t, err)
+	assert.True(t, regExp.Match(bytes), "Event JSON representation (%s) does not match expected regexp (%s)", string(bytes), regExp.String())
+}

--- a/pkg/deppy/pipeline/event/eventidprovider/count.go
+++ b/pkg/deppy/pipeline/event/eventidprovider/count.go
@@ -1,0 +1,26 @@
+package eventidprovider
+
+import (
+	"strconv"
+	"sync/atomic"
+
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline"
+)
+
+var _ pipeline.EventIDProvider = &IncreasingEventIDProvider{}
+
+var provider = &IncreasingEventIDProvider{
+	id: 0,
+}
+
+func MonotonicallyIncreasingEventIDProvider() *IncreasingEventIDProvider {
+	return provider
+}
+
+type IncreasingEventIDProvider struct {
+	id int64
+}
+
+func (i *IncreasingEventIDProvider) NextEventID() pipeline.EventID {
+	return pipeline.EventID(strconv.FormatInt(atomic.AddInt64(&i.id, 1), 10))
+}

--- a/pkg/deppy/pipeline/event/eventidprovider/uuid.go
+++ b/pkg/deppy/pipeline/event/eventidprovider/uuid.go
@@ -1,0 +1,41 @@
+package eventidprovider
+
+import (
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline"
+)
+
+var _ pipeline.EventIDProvider = &UUIDEventIDProvider{}
+
+type UUIDProviderFn func() (uuid.UUID, error)
+
+type UUIDEventIDProvider struct {
+	nextUUIDFn UUIDProviderFn
+}
+
+func NewUUIDEventIDProvider() *UUIDEventIDProvider {
+	return &UUIDEventIDProvider{
+		nextUUIDFn: func() (uuid.UUID, error) { return uuid.NewRandom() },
+	}
+}
+
+func NewCustomUUIDEventIDProvider(nextUUIDFn UUIDProviderFn) *UUIDEventIDProvider {
+	return &UUIDEventIDProvider{
+		nextUUIDFn: nextUUIDFn,
+	}
+}
+
+func (p *UUIDEventIDProvider) NextEventID() pipeline.EventID {
+	eid, err := p.nextUUIDFn()
+	if err != nil {
+		id := err.Error() + time.Now().String()
+		id = hex.EncodeToString([]byte(id))
+		return pipeline.EventID(fmt.Sprintf("%s (with error: %s)", id, err))
+	}
+	return pipeline.EventID(hex.EncodeToString([]byte(eid.String())))
+}

--- a/pkg/deppy/pipeline/event/factory.go
+++ b/pkg/deppy/pipeline/event/factory.go
@@ -1,0 +1,71 @@
+package event
+
+import (
+	"sync"
+	"time"
+
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline"
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline/event/eventidprovider"
+)
+
+var _ pipeline.EventFactory[interface{}] = &eventFactory[interface{}]{}
+
+type FactoryOption[I interface{}] func(factory *eventFactory[I])
+
+func WithEventIDProvider[I interface{}](eventIDProvider pipeline.EventIDProvider) FactoryOption[I] {
+	return func(eventFactory *eventFactory[I]) {
+		eventFactory.eventIDProvider = eventIDProvider
+	}
+}
+
+func WithEventMetadata[I interface{}](eventMetadata pipeline.EventMetadata) FactoryOption[I] {
+	return func(eventFactory *eventFactory[I]) {
+		eventFactory.eventMetadata = eventMetadata
+	}
+}
+
+type eventFactory[I interface{}] struct {
+	eventSourceID   pipeline.EventSourceID
+	eventMetadata   pipeline.EventMetadata
+	eventIDProvider pipeline.EventIDProvider
+}
+
+func NewEventFactory[I interface{}](eventSourceID pipeline.EventSourceID, options ...FactoryOption[I]) pipeline.EventFactory[I] {
+	factory := &eventFactory[I]{
+		eventSourceID: eventSourceID,
+		// eventIDProvider: eventidprovider.NewUUIDEventIDProvider(),
+		eventIDProvider: eventidprovider.MonotonicallyIncreasingEventIDProvider(),
+	}
+
+	for _, applyOption := range options {
+		applyOption(factory)
+	}
+
+	return factory
+}
+
+func (p *eventFactory[I]) NewErrorEvent(err error) pipeline.ErrorEvent {
+	return &errorEvent{
+		event:      newEvent(p.newEventHeader()),
+		EventError: err,
+	}
+}
+
+func (p *eventFactory[I]) NewDataEvent(data I) pipeline.DataEvent[I] {
+	return &dataEvent[I]{
+		event:     newEvent(p.newEventHeader()),
+		EventData: data,
+	}
+}
+
+func (p *eventFactory[I]) newEventHeader() *eventHeader {
+	return &eventHeader{
+		HeaderEventMetadata:    p.eventMetadata,
+		HeaderCreator:          p.eventSourceID,
+		HeaderSender:           p.eventSourceID,
+		HeaderCreationTime:     time.Now(),
+		HeaderEventID:          p.eventIDProvider.NextEventID(),
+		HeaderIsBroadcastEvent: false,
+		lock:                   sync.RWMutex{},
+	}
+}

--- a/pkg/deppy/pipeline/event/header.go
+++ b/pkg/deppy/pipeline/event/header.go
@@ -1,0 +1,91 @@
+package event
+
+import (
+	"sync"
+	"time"
+
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline"
+)
+
+var _ pipeline.EventHeader = &eventHeader{}
+
+type eventHeader struct {
+	HeaderEventID          pipeline.EventID       `json:"eventID"`
+	HeaderCreator          pipeline.EventSourceID `json:"creatorEventSourceID"`
+	HeaderSender           pipeline.EventSourceID `json:"sender"`
+	HeaderReceiver         pipeline.EventSourceID `json:"receiver,omitempty"`
+	HeaderIsBroadcastEvent bool                   `json:"broadcast"`
+	HeaderCreationTime     time.Time              `json:"creationTime"`
+	HeaderEventMetadata    pipeline.EventMetadata `json:"metadata,omitempty"`
+	lock                   sync.RWMutex
+}
+
+func (p *eventHeader) route(receiver pipeline.EventSourceID) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.HeaderIsBroadcastEvent = false
+	p.HeaderReceiver = receiver
+}
+
+func (p *eventHeader) broadcast() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.HeaderReceiver = ""
+	p.HeaderIsBroadcastEvent = true
+}
+
+func (p *eventHeader) copy() *eventHeader {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return &eventHeader{
+		HeaderEventID:          p.HeaderEventID,
+		HeaderSender:           p.HeaderSender,
+		HeaderCreator:          p.HeaderCreator,
+		HeaderReceiver:         p.HeaderReceiver,
+		HeaderIsBroadcastEvent: p.HeaderIsBroadcastEvent,
+		HeaderEventMetadata:    p.HeaderEventMetadata,
+		HeaderCreationTime:     p.HeaderCreationTime,
+	}
+}
+
+func (p *eventHeader) EventID() pipeline.EventID {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.HeaderEventID
+}
+
+func (p *eventHeader) Creator() pipeline.EventSourceID {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.HeaderCreator
+}
+
+func (p *eventHeader) Sender() pipeline.EventSourceID {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.HeaderSender
+}
+
+func (p *eventHeader) Receiver() pipeline.EventSourceID {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.HeaderReceiver
+}
+
+func (p *eventHeader) IsBroadcastEvent() bool {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.HeaderIsBroadcastEvent
+}
+
+func (p *eventHeader) CreationTime() time.Time {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.HeaderCreationTime
+}
+
+func (p *eventHeader) Metadata() pipeline.EventMetadata {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.HeaderEventMetadata
+}

--- a/pkg/deppy/pipeline/route/options.go
+++ b/pkg/deppy/pipeline/route/options.go
@@ -1,0 +1,17 @@
+package route
+
+import "github.com/operator-framework/deppy/pkg/deppy/pipeline"
+
+type Option func(router *Router)
+
+func WithDebugChannel(debugChannel chan<- pipeline.Event) Option {
+	return func(router *Router) {
+		router.debugChannel = debugChannel
+	}
+}
+
+func WithErrorChannel(errChannel chan<- pipeline.ErrorEvent) Option {
+	return func(router *Router) {
+		router.errChannel = errChannel
+	}
+}

--- a/pkg/deppy/pipeline/route/route.go
+++ b/pkg/deppy/pipeline/route/route.go
@@ -1,0 +1,64 @@
+package route
+
+import (
+	"context"
+	"sync"
+
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline"
+)
+
+// Route is a part of Routing table that tracks the input and output
+// channel of the event source
+type Route struct {
+	// Event Source Id
+	eventSourceID pipeline.EventSourceID
+	// source of the event
+	inputChannel chan pipeline.Event
+	// Destination channel
+	outputChannel chan pipeline.Event
+	// whether the input channel has been closed, can happen when:
+	// 1. the event source has closed its output channel (signalling end-of-output/processing)
+	// 2. closed by an auto-close because all input sources into this event source have closed their output channels (end-of-input)
+	inputChannelClosed bool
+	// both input and output channels are closed
+	connectionDoneListeners map[chan<- struct{}]struct{}
+
+	lock sync.RWMutex
+}
+
+func (c *Route) CloseInputChannel() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if !c.inputChannelClosed && c.inputChannel != nil {
+		close(c.inputChannel)
+		c.inputChannelClosed = true
+	}
+}
+
+func (c *Route) InputChannel() <-chan pipeline.Event {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.inputChannel
+}
+
+func (c *Route) OutputChannel() chan<- pipeline.Event {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.outputChannel
+}
+
+func (c *Route) notifyConnectionDoneListeners(ctx context.Context) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	for doneCh := range c.connectionDoneListeners {
+		go func(doneCh chan<- struct{}) {
+			select {
+			case <-ctx.Done():
+				return
+			case doneCh <- struct{}{}:
+				return
+			}
+		}(doneCh)
+	}
+}

--- a/pkg/deppy/pipeline/route/route.go
+++ b/pkg/deppy/pipeline/route/route.go
@@ -26,12 +26,12 @@ type Route struct {
 	lock sync.RWMutex
 }
 
-func (c *Route) CloseInputChannel() {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if !c.inputChannelClosed && c.inputChannel != nil {
-		close(c.inputChannel)
-		c.inputChannelClosed = true
+func (r *Route) CloseInputChannel() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if !r.inputChannelClosed && r.inputChannel != nil {
+		close(r.inputChannel)
+		r.inputChannelClosed = true
 	}
 }
 
@@ -61,4 +61,9 @@ func (c *Route) notifyConnectionDoneListeners(ctx context.Context) {
 			}
 		}(doneCh)
 	}
+}
+
+func (c *Route) ConnectionDone(ctx context.Context) {
+	c.CloseInputChannel()
+	c.notifyConnectionDoneListeners(ctx)
 }

--- a/pkg/deppy/pipeline/route/route_test.go
+++ b/pkg/deppy/pipeline/route/route_test.go
@@ -1,0 +1,87 @@
+package route
+
+import (
+	"sync"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline"
+)
+
+var _ = Describe("Route", func() {
+	defer GinkgoRecover()
+
+	var (
+		testroute *Route
+	)
+
+	BeforeEach(func() {
+		testroute = &Route{
+			eventSourceID:           pipeline.EventSourceID("testEvent"),
+			inputChannel:            make(chan pipeline.Event),
+			outputChannel:           make(chan pipeline.Event),
+			connectionDoneListeners: make(map[chan<- struct{}]struct{}),
+			lock:                    sync.RWMutex{},
+		}
+	})
+
+	When("closing of Channel", func() {
+		It("closing a non-nil channel", func() {
+			testroute.inputChannelClosed = false
+			testroute.CloseInputChannel()
+			Expect(testroute.inputChannelClosed).To(BeTrue())
+			Expect(isClosed(testroute.inputChannel)).To(BeTrue())
+		})
+
+		It("closing an already closed channel", func() {
+			By("closing the channel before ")
+			close(testroute.inputChannel)
+			testroute.inputChannelClosed = true
+
+			By("making sure it doesn't panic")
+			Expect(func() {
+				testroute.CloseInputChannel()
+			}).NotTo(Panic())
+			Expect(testroute.inputChannelClosed).To(BeTrue())
+		})
+
+		It("closing a nil channel", func() {
+			By("setting input channel parameters")
+			testroute.inputChannelClosed = false
+			testroute.inputChannel = nil
+
+			By("making sure it doesn't panic")
+			Expect(func() {
+				testroute.CloseInputChannel()
+			}).NotTo(Panic())
+		})
+	})
+
+	When("fetching input and output channel", func() {
+		It("should fetch input and output channels correctly", func() {
+			Expect(testroute.InputChannel()).NotTo(BeNil())
+			Expect(testroute.OutputChannel()).NotTo(BeNil())
+		})
+	})
+
+	When("notifyConnectionDoneListers", func() {
+		// TODO: finish up tests for this
+
+	})
+
+})
+
+func TestRoute(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Route tests")
+}
+
+func isClosed(ch <-chan pipeline.Event) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+	}
+	return false
+}

--- a/pkg/deppy/pipeline/route/route_test.go
+++ b/pkg/deppy/pipeline/route/route_test.go
@@ -72,11 +72,6 @@ var _ = Describe("Route", func() {
 
 })
 
-func TestRoute(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Route tests")
-}
-
 func isClosed(ch <-chan pipeline.Event) bool {
 	select {
 	case <-ch:
@@ -84,4 +79,9 @@ func isClosed(ch <-chan pipeline.Event) bool {
 	default:
 	}
 	return false
+}
+
+func TestRoute(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Route tests")
 }

--- a/pkg/deppy/pipeline/route/router.go
+++ b/pkg/deppy/pipeline/route/router.go
@@ -1,0 +1,179 @@
+package route
+
+import (
+	"context"
+	"sync"
+
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline"
+)
+
+type Router struct {
+	// contains entries that map the route table and the route.
+	routeTable map[pipeline.EventSourceID]*Route
+	// debugChannel to send debug events
+	debugChannel chan<- pipeline.Event
+	// errChannel to send error events
+	errChannel chan<- pipeline.ErrorEvent
+	lock       sync.RWMutex
+	ctx        context.Context
+}
+
+func NewEventRouter(ctx context.Context, opts ...Option) *Router {
+	router := &Router{
+		routeTable: map[pipeline.EventSourceID]*Route{},
+		lock:       sync.RWMutex{},
+		ctx:        ctx,
+	}
+
+	for _, applyOption := range opts {
+		applyOption(router)
+	}
+
+	// close debug and error channel when context expires
+	if router.debugChannel != nil {
+		go func(router *Router) {
+			<-router.ctx.Done()
+			close(router.debugChannel)
+		}(router)
+	}
+
+	if router.errChannel != nil {
+		go func(router *Router) {
+			<-router.ctx.Done()
+			close(router.errChannel)
+		}(router)
+	}
+	return router
+}
+
+func (r *Router) AddRoute(eventSource pipeline.EventSource) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if _, ok := r.routeTable[eventSource.EventSourceID()]; !ok {
+		conn := Route{
+			eventSourceID:           eventSource.EventSourceID(),
+			inputChannel:            make(chan pipeline.Event),
+			outputChannel:           make(chan pipeline.Event),
+			connectionDoneListeners: map[chan<- struct{}]struct{}{},
+			inputChannelClosed:      false,
+		}
+		r.routeTable[eventSource.EventSourceID()] = &conn
+		return true
+	}
+	return false
+}
+
+// DeleteRoute deletes a particular route from the routing table.
+func (r *Router) DeleteRoute(eventSourceID pipeline.EventSourceID) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	delete(r.routeTable, eventSourceID)
+}
+
+// send a debug event through the debug channel
+func (r *Router) debug(event pipeline.Event) {
+	if r.debugChannel != nil {
+		select {
+		case r.debugChannel <- event:
+			return
+		case <-r.ctx.Done():
+			return
+		}
+	}
+}
+
+// send a debug event through the error channel
+func (r *Router) error(event pipeline.ErrorEvent) {
+	if r.errChannel != nil {
+		select {
+		case r.errChannel <- event:
+			return
+		case <-r.ctx.Done():
+			return
+		}
+	}
+}
+
+func (r *Router) Route(event pipeline.Event, receiverEventSource pipeline.EventSource) {
+	route, ok := r.routeTable[receiverEventSource.EventSourceID()]
+	if !ok {
+		// TODO: send an error event in the error channel
+		return
+	}
+
+	go func(rte *Route) {
+		defer func() {
+			// Delete the event sourceID from the router after routing.
+			r.DeleteRoute(rte.eventSourceID)
+			// close the connection
+			rte.ConnectionDone(r.ctx)
+		}()
+
+		for {
+			select {
+			case <-r.ctx.Done():
+				return
+			case event, hasNext := <-rte.outputChannel:
+				if !hasNext {
+					return
+				}
+				r.route(event)
+			}
+		}
+	}(route)
+}
+
+// route an event based on the header information on the event
+func (r *Router) route(event pipeline.Event) {
+	// debug is a blocking call if the debug channel is set
+	r.debug(event)
+
+	if event.Header().IsBroadcastEvent() {
+		conns := r.getAllRoutes()
+
+		for _, conn := range conns {
+			if conn.eventSourceID != event.Header().Sender() {
+				func() {
+					select {
+					case conn.inputChannel <- event:
+						return
+					case <-r.ctx.Done():
+						return
+					}
+				}()
+			}
+		}
+	} else if event.Header().Receiver() != "" {
+		conn, ok := r.GetReceiver(event.Header().Receiver())
+		if !ok {
+			// TODO: create an error event and send it through the error channel.
+		} else {
+			select {
+			case conn.inputChannel <- event:
+				return
+			case <-r.ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// RouteTo returns the route for the particular event source from the routing table.
+func (r *Router) GetReceiver(eventSourceID pipeline.EventSourceID) (*Route, bool) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	conn, ok := r.routeTable[eventSourceID]
+	return conn, ok
+}
+
+func (r *Router) getAllRoutes() []*Route {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	var out []*Route
+	for _, conn := range r.routeTable {
+		out = append(out, conn)
+	}
+	return out
+}

--- a/pkg/deppy/pipeline/route/router_test.go
+++ b/pkg/deppy/pipeline/route/router_test.go
@@ -1,0 +1,139 @@
+package route
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline"
+	"github.com/operator-framework/deppy/pkg/deppy/pipeline/event"
+)
+
+var _ = Describe("Router", func() {
+	defer GinkgoRecover()
+
+	var (
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+	})
+
+	When("test creating of new router", func() {
+		It("creating a new router", func() {
+			router := NewEventRouter(ctx)
+			Expect(router.routeTable).NotTo(BeNil())
+			Expect(router.ctx).NotTo(BeNil())
+			Expect(router.debugChannel).To(BeNil())
+			Expect(router.errChannel).To(BeNil())
+		})
+
+		It("create a new router with options", func() {
+			debugChannel := make(chan<- pipeline.Event)
+			errChannel := make(chan<- pipeline.ErrorEvent)
+
+			router := NewEventRouter(ctx, WithDebugChannel(debugChannel), WithErrorChannel(errChannel))
+			Expect(router.routeTable).NotTo(BeNil())
+			Expect(router.ctx).NotTo(BeNil())
+			Expect(router.debugChannel).NotTo(BeNil())
+			Expect(router.errChannel).NotTo(BeNil())
+		})
+	})
+
+	When("adding a route", func() {
+		var (
+			router *Router
+		)
+		BeforeEach(func() {
+			router = NewEventRouter(ctx)
+		})
+
+		It("Adding a new route", func() {
+			testSource := &testeventSource{"node"}
+			res := router.AddRoute(testSource)
+			Expect(res).To(BeTrue())
+			Expect(len(router.routeTable)).To(BeEquivalentTo(1))
+
+			conn := router.routeTable[testSource.EventSourceID()]
+			Expect(conn).NotTo(BeNil())
+			Expect(conn.eventSourceID).To(BeEquivalentTo(testSource.EventSourceID()))
+			Expect(conn.inputChannel).NotTo(BeNil())
+			Expect(conn.outputChannel).NotTo(BeNil())
+			Expect(conn.connectionDoneListeners).NotTo(BeNil())
+		})
+
+		It("Adding an existing route again", func() {
+			testSource1 := &testeventSource{"node"}
+			testSource2 := &testeventSource{"node"}
+
+			res := router.AddRoute(testSource1)
+			Expect(res).To(BeTrue())
+
+			res = router.AddRoute(testSource2)
+			Expect(res).To(BeFalse())
+
+			Expect(len(router.routeTable)).To(BeEquivalentTo(1))
+		})
+
+		It("Adding different routes", func() {
+			testSource1 := &testeventSource{"node1"}
+			testSource2 := &testeventSource{"node2"}
+
+			res := router.AddRoute(testSource1)
+			Expect(res).To(BeTrue())
+
+			res = router.AddRoute(testSource2)
+			Expect(res).To(BeTrue())
+
+			Expect(len(router.routeTable)).To(BeEquivalentTo(2))
+		})
+	})
+
+	When("routing an event", func() {
+		var (
+			router *Router
+		)
+		BeforeEach(func() {
+			router = NewEventRouter(ctx)
+			Expect(router.debugChannel).To(BeNil())
+
+			testSource := &testeventSource{"node"}
+			router.AddRoute(testSource)
+		})
+
+		It("routes the event as expected", func() {
+			evt := getNewTestEvent()
+			evt.Broadcast()
+
+			Expect(func() {
+				router.route(evt)
+			}).NotTo(Panic())
+
+			router.ctx.Done()
+		})
+
+	})
+
+})
+
+func TestRouter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Router tests")
+}
+
+func getNewTestEvent() pipeline.Event {
+	factory := event.NewEventFactory[string]("testnode")
+	return factory.NewDataEvent("testEvent")
+}
+
+type testeventSource struct {
+	eventsourceID string
+}
+
+var _ pipeline.EventSource = &testeventSource{}
+
+func (t *testeventSource) EventSourceID() pipeline.EventSourceID {
+	return pipeline.EventSourceID(t.eventsourceID)
+}


### PR DESCRIPTION
This PR adds the logic for routing events with the help of routing table. The routing table consists of eventSourceIDs and their specific routes. The helpers are useful in routing an event to the necessary destination.

This is based on the work done by @perdasilva in https://github.com/perdasilva/olmcli