### PR TITLE
[EntitySource] Modify entity source interface

### DIFF
--- a/pkg/deppy/input/cache_entity_source.go
+++ b/pkg/deppy/input/cache_entity_source.go
@@ -2,6 +2,7 @@ package input
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/operator-framework/deppy/pkg/deppy"
 )
@@ -19,11 +20,11 @@ func NewCacheQuerier(entities map[deppy.Identifier]Entity) *CacheEntitySource {
 	}
 }
 
-func (c CacheEntitySource) Get(_ context.Context, id deppy.Identifier) *Entity {
+func (c CacheEntitySource) Get(_ context.Context, id deppy.Identifier) (*Entity, error) {
 	if entity, ok := c.entities[id]; ok {
-		return &entity
+		return &entity, nil
 	}
-	return nil
+	return nil, fmt.Errorf("entity with id: %s not found in the entity source", id.String())
 }
 
 func (c CacheEntitySource) Filter(_ context.Context, filter Predicate) (EntityList, error) {

--- a/pkg/deppy/input/entity_source.go
+++ b/pkg/deppy/input/entity_source.go
@@ -24,7 +24,7 @@ type EntityListMap map[string]EntityList
 
 // EntitySource provides a query and content acquisition interface for arbitrary entity stores
 type EntitySource interface {
-	Get(ctx context.Context, id deppy.Identifier) *Entity
+	Get(ctx context.Context, id deppy.Identifier) (*Entity, error)
 	Filter(ctx context.Context, filter Predicate) (EntityList, error)
 	GroupBy(ctx context.Context, fn GroupByFunction) (EntityListMap, error)
 	Iterate(ctx context.Context, fn IteratorFunction) error

--- a/pkg/deppy/input/entity_source_test.go
+++ b/pkg/deppy/input/entity_source_test.go
@@ -90,9 +90,17 @@ var _ = Describe("EntitySource", func() {
 
 		Describe("Get", func() {
 			It("should return requested entity", func() {
-				e := entitySource.Get(context.Background(), "2-2")
+				e, err := entitySource.Get(context.Background(), "2-2")
+				Expect(err).To(BeNil())
 				Expect(e).NotTo(BeNil())
 				Expect(e.Identifier()).To(Equal(deppy.Identifier("2-2")))
+			})
+
+			It("should return an error when the requested entity is not found", func() {
+				e, err := entitySource.Get(context.Background(), "random")
+				Expect(err).To(HaveOccurred())
+				Expect(e).To(BeNil())
+				Expect(err.Error()).To(BeEquivalentTo(fmt.Sprintf("entity with id: %s not found in the entity source", "random")))
 			})
 		})
 

--- a/pkg/ext/olm/constraints_test.go
+++ b/pkg/ext/olm/constraints_test.go
@@ -59,8 +59,8 @@ type MockQuerier struct {
 	testEntityList input.EntityList
 }
 
-func (t MockQuerier) Get(_ context.Context, _ deppy.Identifier) *input.Entity {
-	return &input.Entity{}
+func (t MockQuerier) Get(_ context.Context, _ deppy.Identifier) (*input.Entity, error) {
+	return &input.Entity{}, nil
 }
 func (t MockQuerier) Filter(_ context.Context, filter input.Predicate) (input.EntityList, error) {
 	if t.testError != nil {


### PR DESCRIPTION
The "Get" function of the entity source did not return an error and instead only a nil entity when its not found. This PR modifies the same, to make it return an error.

Reason:
The method could be implmented with a client that fetches bundle contents from the cluster. The error returned from the client needs to be propagated. Even if its from an offline key-value store, it could be upto the library users to ignore the returned error. 

More info: https://github.com/operator-framework/operator-controller/pull/141#discussion_r1163271945