### PR TITLE
Updates github actions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,8 +11,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
       - name: Run the e2e suite

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -11,8 +11,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
       - name: Run verification checks
@@ -20,21 +21,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
-
-      - name: Cache build and module paths
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Run golangci linting checks
         run: make lint

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -11,8 +11,8 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
       - run: make unit


### PR DESCRIPTION
This helps to simplify workflow yamls a bit since we don't need to explicity use cache for go steps: `actions/setup-go@v4` does that for us by default.