### PR TITLE
Improving linter reporting in github actions

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -37,4 +37,4 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run golangci linting checks
-        run: make lint
+        run: make lint GOLANGCI_LINT_ARGS="--out-format github-actions"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ tidy: ## Update modules.
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter checks.
-	$(GOLANGCI_LINT) run
+	$(GOLANGCI_LINT) run $(GOLANGCI_LINT_ARGS)
 
 .PHONY: verify
 verify: tidy ## Run verification checks.


### PR DESCRIPTION
Similar change in rukpak: https://github.com/operator-framework/rukpak/pull/631

With this change linter will be reporting in github-actions format which will then be displayed in-line in the PR diff like this:

![Screenshot](https://github.com/operator-framework/rukpak/assets/509198/7eba0b2c-3c09-428e-a77d-e09ee203033a)

Github action run summary will also have this information.