### PR TITLE
Adds `ginkgolinter`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
   - asciicheck
   - bodyclose
   - errorlint
+  - ginkgolinter
   - gofmt
   - goimports
   - importas

--- a/cmd/dimacs/dimacs_test.go
+++ b/cmd/dimacs/dimacs_test.go
@@ -19,17 +19,17 @@ var _ = Describe("Dimacs", func() {
 	It("should fail if there is no header", func() {
 		problem := "1 2 3 0\n"
 		_, err := dimacs.NewDimacs(bytes.NewReader([]byte(problem)))
-		Expect(err).ToNot(BeNil())
+		Expect(err).To(HaveOccurred())
 	})
 	It("should fail if there are no clauses", func() {
 		problem := "p cnf 3 3\n"
 		_, err := dimacs.NewDimacs(bytes.NewReader([]byte(problem)))
-		Expect(err).ToNot(BeNil())
+		Expect(err).To(HaveOccurred())
 	})
 	It("should parse valid dimacs", func() {
 		problem := "p cnf 3 1\n1 2 3 0\n"
 		d, err := dimacs.NewDimacs(bytes.NewReader([]byte(problem)))
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(d.Variables()).To(Equal([]string{"1", "2", "3"}))
 		Expect(d.Clauses()).To(Equal([]string{"1 2 3"}))
 	})

--- a/pkg/deppy/input/entity_source_test.go
+++ b/pkg/deppy/input/entity_source_test.go
@@ -91,7 +91,7 @@ var _ = Describe("EntitySource", func() {
 		Describe("Get", func() {
 			It("should return requested entity", func() {
 				e, err := entitySource.Get(context.Background(), "2-2")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(e).NotTo(BeNil())
 				Expect(e.Identifier()).To(Equal(deppy.Identifier("2-2")))
 			})
@@ -110,7 +110,7 @@ var _ = Describe("EntitySource", func() {
 					return fmt.Sprintf("%v", element)
 				}
 				el, err := entitySource.Filter(context.Background(), input.Or(byIndex("2"), bySource("1")))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(el).To(MatchAllElements(id, Elements{
 					"{1-2 map[index:2 source:1]}": Not(BeNil()),
 					"{2-2 map[index:2 source:2]}": Not(BeNil()),
@@ -125,7 +125,7 @@ var _ = Describe("EntitySource", func() {
 				}))
 
 				el, err = entitySource.Filter(context.Background(), input.And(byIndex("2"), bySource("1")))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(el).To(MatchAllElements(id, Elements{
 					"{1-2 map[index:2 source:1]}": Not(BeNil()),
 				}))
@@ -136,7 +136,7 @@ var _ = Describe("EntitySource", func() {
 				}))
 
 				el, err = entitySource.Filter(context.Background(), input.And(byIndex("2"), input.Not(bySource("1"))))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(el).To(MatchAllElements(id, Elements{
 					"{2-2 map[index:2 source:2]}": Not(BeNil()),
 				}))
@@ -153,7 +153,7 @@ var _ = Describe("EntitySource", func() {
 			It("should go through all entities", func() {
 				entityCheck = map[deppy.Identifier]bool{"1-1": false, "1-2": false, "2-1": false, "2-2": false}
 				err := entitySource.Iterate(context.Background(), check)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				for _, value := range entityCheck {
 					Expect(value).To(BeTrue())
 				}
@@ -166,7 +166,7 @@ var _ = Describe("EntitySource", func() {
 					return fmt.Sprintf("%v", element)
 				}
 				grouped, err := entitySource.GroupBy(context.Background(), bySourceAndIndex)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(grouped).To(MatchAllKeys(Keys{
 					"index 1":  Not(BeNil()),
 					"index 2":  Not(BeNil()),


### PR DESCRIPTION
Linter which checks for common ginkgo issues like wrong error assertions (`Expect(err).To(BeNil())` instead of 
`Expect(err).NotTo(HaveOccurred())`), etc.

It also identifies `Expect` calls without a matcher.

See https://github.com/operator-framework/rukpak/pull/637 for examples where it was super useful.