### PR TITLE
Adds go module caching for bingo modules

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,5 +15,8 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
+          cache-dependency-path: |
+            go.sum
+            .bingo/**.sum
       - name: Run the e2e suite
         run: make e2e

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -16,6 +16,9 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
+          cache-dependency-path: |
+            go.sum
+            .bingo/**.sum
       - name: Run verification checks
         run: make verify
   lint:
@@ -26,6 +29,9 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
+          cache-dependency-path: |
+            go.sum
+            .bingo/**.sum
 
       - name: Run golangci linting checks
         run: make lint GOLANGCI_LINT_ARGS="--out-format github-actions"

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
+          cache-dependency-path: |
+            go.sum
+            .bingo/**.sum
       - run: make unit
 
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
We introduced [bingo](https://github.com/bwplotka/bingo) in OLMv1 repos for managing tools and it created a bunch of modules in the `.bingo` directory in each repo. It works well, but on every job we download these dependencies from internet instead of using cache. This happens becuase setup-go github action only looks into project root for `go.sum` and builds cache based on it.

`cache-dependency-path` needs to be added to all OLMv1 repos and it should speed up our builds (we've seen decrease in build time of ~3 minutes in https://github.com/operator-framework/olm-docs).