### PR TITLE
✨ Replace separator in `NotSatisfiable` error

### DIFF
--- a/internal/solver/solve_test.go
+++ b/internal/solver/solve_test.go
@@ -65,7 +65,7 @@ func TestNotSatisfiableError(t *testing.T) {
 					Constraint: constraint.Mandatory(),
 				},
 			},
-			String: fmt.Sprintf("constraints not satisfiable: %s",
+			String: fmt.Sprintf("constraints not satisfiable:\n%s",
 				constraint.Mandatory().String("a")),
 		},
 		{
@@ -80,7 +80,7 @@ func TestNotSatisfiableError(t *testing.T) {
 					Constraint: constraint.Prohibited(),
 				},
 			},
-			String: fmt.Sprintf("constraints not satisfiable: %s, %s",
+			String: fmt.Sprintf("constraints not satisfiable:\n%s\n%s",
 				constraint.Mandatory().String("a"), constraint.Prohibited().String("b")),
 		},
 	} {

--- a/pkg/deppy/api.go
+++ b/pkg/deppy/api.go
@@ -21,7 +21,7 @@ func (e NotSatisfiable) Error() string {
 	for i, a := range e {
 		s[i] = a.String()
 	}
-	return fmt.Sprintf("%s: %s", msg, strings.Join(s, ", "))
+	return fmt.Sprintf("%s:\n%s", msg, strings.Join(s, "\n"))
 }
 
 // Identifier values uniquely identify particular Variables within


### PR DESCRIPTION
Use new line instead of comma as a separator.

Example from operator-controller as yaml:

```yaml
status:
  conditions:
  - lastTransitionTime: "2023-11-13T13:43:28Z"
    message: |-
      constraints not satisfiable:
      argocd-operator package uniqueness permits at most 1 of operatorhubio-argocd-operator-argocd-operator.v0.6.0, operatorhubio-argocd-operator-argocd-operator.v0.4.0
      installed package argocd-operator requires at least one of operatorhubio-argocd-operator-argocd-operator.v0.4.0
      installed package argocd-operator is mandatory
      required package argocd-operator requires at least one of operatorhubio-argocd-operator-argocd-operator.v0.6.0
      required package argocd-operator is mandatory
    observedGeneration: 2
    reason: ResolutionFailed
    status: "False"
    type: Resolved
```

And as json:

```json
{
    "status": {
        "conditions": [
            {
                "lastTransitionTime": "2023-11-13T13:43:28Z",
                "message": "constraints not satisfiable:\nargocd-operator package uniqueness permits at most 1 of operatorhubio-argocd-operator-argocd-operator.v0.6.0, operatorhubio-argocd-operator-argocd-operator.v0.4.0\ninstalled package argocd-operator requires at least one of operatorhubio-argocd-operator-argocd-operator.v0.4.0\ninstalled package argocd-operator is mandatory\nrequired package argocd-operator requires at least one of operatorhubio-argocd-operator-argocd-operator.v0.6.0\nrequired package argocd-operator is mandatory",
                "observedGeneration": 2,
                "reason": "ResolutionFailed",
                "status": "False",
                "type": "Resolved"
            }
        ]
    }
}
```

Closes #150