### PR TITLE
🌱 Update the internal solver before exporting

### DIFF
--- a/internal/solver/bench_test.go
+++ b/internal/solver/bench_test.go
@@ -68,20 +68,11 @@ var BenchmarkInput = func() []deppy.Variable {
 
 func BenchmarkSolve(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		s, err := NewSolver(WithInput(BenchmarkInput))
+		s, err := New()
 		if err != nil {
 			b.Fatalf("failed to initialize solver: %s", err)
 		}
-		_, err = s.Solve()
-		if err != nil {
-			b.Fatalf("failed to initialize solver: %s", err)
-		}
-	}
-}
-
-func BenchmarkNewInput(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_, err := NewSolver(WithInput(BenchmarkInput))
+		_, err = s.Solve(BenchmarkInput)
 		if err != nil {
 			b.Fatalf("failed to initialize solver: %s", err)
 		}

--- a/internal/solver/search.go
+++ b/internal/solver/search.go
@@ -1,8 +1,6 @@
 package solver
 
 import (
-	"context"
-
 	"github.com/go-air/gini/inter"
 	"github.com/go-air/gini/z"
 
@@ -157,7 +155,7 @@ func (h *search) Lits() []z.Lit {
 	return result
 }
 
-func (h *search) Do(_ context.Context, anchors []z.Lit) (int, []z.Lit, map[z.Lit]struct{}) {
+func (h *search) Do(anchors []z.Lit) (int, []z.Lit, map[z.Lit]struct{}) {
 	for _, m := range anchors {
 		h.PushChoiceBack(choice{candidates: []z.Lit{m}})
 	}

--- a/internal/solver/search_test.go
+++ b/internal/solver/search_test.go
@@ -3,7 +3,6 @@
 package solver
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-air/gini/inter"
@@ -96,7 +95,7 @@ func TestSearch(t *testing.T) {
 				anchors = append(anchors, h.lits.LitOf(id))
 			}
 
-			result, ms, _ := h.Do(context.Background(), anchors)
+			result, ms, _ := h.Do(anchors)
 
 			assert.Equal(tt.Result, result)
 			var ids []deppy.Identifier

--- a/internal/solver/solve_test.go
+++ b/internal/solver/solve_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/operator-framework/deppy/pkg/deppy/constraint"
 
@@ -290,12 +291,12 @@ func TestSolve(t *testing.T) {
 			assert := assert.New(t)
 
 			var traces bytes.Buffer
-			s, err := NewSolver(WithInput(tt.Variables), WithTracer(LoggingTracer{Writer: &traces}))
+			s, err := New(WithTracer(LoggingTracer{Writer: &traces}))
 			if err != nil {
 				t.Fatalf("failed to initialize solver: %s", err)
 			}
 
-			installed, err := s.Solve()
+			installed, err := s.Solve(tt.Variables)
 
 			var ids []deppy.Identifier
 			for _, variable := range installed {
@@ -312,9 +313,12 @@ func TestSolve(t *testing.T) {
 }
 
 func TestDuplicateIdentifier(t *testing.T) {
-	_, err := NewSolver(WithInput([]deppy.Variable{
+	s, err := New()
+	require.NoError(t, err)
+
+	_, err = s.Solve([]deppy.Variable{
 		variable("a"),
 		variable("a"),
-	}))
+	})
 	assert.Equal(t, DuplicateIdentifier("a"), err)
 }

--- a/pkg/deppy/solver/solver.go
+++ b/pkg/deppy/solver/solver.go
@@ -46,12 +46,12 @@ func NewDeppySolver() *DeppySolver {
 }
 
 func (d DeppySolver) Solve(vars []deppy.Variable) (*Solution, error) {
-	satSolver, err := solver.NewSolver(solver.WithInput(vars))
+	satSolver, err := solver.New()
 	if err != nil {
 		return nil, err
 	}
 
-	selection, err := satSolver.Solve()
+	selection, err := satSolver.Solve(vars)
 	if err != nil && !errors.As(err, &deppy.NotSatisfiable{}) {
 		return nil, err
 	}


### PR DESCRIPTION
Related to #161

Preparing the internal solver to be exported and used without [the `DeppySolver` wrapper](https://github.com/operator-framework/deppy/blob/e676ccebc62ac3a514bf381d1647fc7d9da13bd0/pkg/deppy/solver/solver.go#L40-L72).